### PR TITLE
Edit conformance test to output log

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -1036,6 +1036,7 @@ func (r *Request) request(ctx context.Context, fn func(*http.Request, *http.Resp
 //   - http.Client.Do errors are returned directly.
 func (r *Request) Do(ctx context.Context) Result {
 	var result Result
+	fmt.Printf("\n[MYLOG] HTTP REQ:%s::%#v\n", r.namespace, r)
 	err := r.request(ctx, func(req *http.Request, resp *http.Response) {
 		result = r.transformResponse(resp, req)
 	})

--- a/test/conformance/gen-specsummaries.sh
+++ b/test/conformance/gen-specsummaries.sh
@@ -26,4 +26,4 @@ cd "${KUBE_ROOT}"
 hack/make-rules/build.sh github.com/onsi/ginkgo/v2/ginkgo test/e2e/e2e.test
 
 # dump spec
-./_output/bin/ginkgo --seed=0 --dry-run=true --focus='[Conformance]' ./_output/bin/e2e.test -- --spec-dump "${KUBE_ROOT}/_output/specsummaries.json" > /dev/null
+./_output/bin/ginkgo --seed=17 --dry-run=true --focus='[Conformance]' ./_output/bin/e2e.test -- --spec-dump "${KUBE_ROOT}/_output/specsummaries.json" > /dev/null

--- a/test/conformance/gen-specsummaries.sh
+++ b/test/conformance/gen-specsummaries.sh
@@ -26,4 +26,4 @@ cd "${KUBE_ROOT}"
 hack/make-rules/build.sh github.com/onsi/ginkgo/v2/ginkgo test/e2e/e2e.test
 
 # dump spec
-./_output/bin/ginkgo --seed=0 --dry-run=true --focus='[Conformance]' ./_output/bin/e2e.test -- --spec-dump "${KUBE_ROOT}/_output/specsummaries.json" > /dev/null
+./_output/bin/ginkgo --dry-run=true --focus='[Conformance]' ./_output/bin/e2e.test -- --spec-dump "${KUBE_ROOT}/_output/specsummaries.json" > /dev/null

--- a/test/conformance/gen-specsummaries.sh
+++ b/test/conformance/gen-specsummaries.sh
@@ -26,4 +26,4 @@ cd "${KUBE_ROOT}"
 hack/make-rules/build.sh github.com/onsi/ginkgo/v2/ginkgo test/e2e/e2e.test
 
 # dump spec
-./_output/bin/ginkgo --dry-run=true --focus='[Conformance]' ./_output/bin/e2e.test -- --spec-dump "${KUBE_ROOT}/_output/specsummaries.json" > /dev/null
+./_output/bin/ginkgo --seed=0 --dry-run=true --focus='[Conformance]' ./_output/bin/e2e.test -- --spec-dump "${KUBE_ROOT}/_output/specsummaries.json" > /dev/null

--- a/test/conformance/image/go-runner/cmd.go
+++ b/test/conformance/image/go-runner/cmd.go
@@ -42,7 +42,7 @@ func getCmd(env Getenver, w io.Writer) *exec.Cmd {
 	ginkgoArgs = append(ginkgoArgs, []string{
 		"--focus=" + env.Getenv(focusEnvKey),
 		"--skip=" + skip,
-		"--noColor=true", " --seed=0",
+		"--noColor=true", "--seed=17",
 	}...)
 
 	extraArgs := []string{

--- a/test/conformance/image/go-runner/cmd.go
+++ b/test/conformance/image/go-runner/cmd.go
@@ -42,7 +42,7 @@ func getCmd(env Getenver, w io.Writer) *exec.Cmd {
 	ginkgoArgs = append(ginkgoArgs, []string{
 		"--focus=" + env.Getenv(focusEnvKey),
 		"--skip=" + skip,
-		"--noColor=true", " --seed=0",
+		"--noColor=true",
 	}...)
 
 	extraArgs := []string{

--- a/test/conformance/image/go-runner/cmd.go
+++ b/test/conformance/image/go-runner/cmd.go
@@ -42,7 +42,7 @@ func getCmd(env Getenver, w io.Writer) *exec.Cmd {
 	ginkgoArgs = append(ginkgoArgs, []string{
 		"--focus=" + env.Getenv(focusEnvKey),
 		"--skip=" + skip,
-		"--noColor=true",
+		"--noColor=true", " --seed=0",
 	}...)
 
 	extraArgs := []string{

--- a/test/conformance/image/go-runner/cmd_test.go
+++ b/test/conformance/image/go-runner/cmd_test.go
@@ -38,7 +38,7 @@ func TestGetCmd(t *testing.T) {
 			},
 			expectArgs: []string{
 				"ginkgobin",
-				"--focus=", "--skip=", " --seed=0",
+				"--focus=", "--skip=",
 				"--noColor=true", "--timeout=24h", "testbin", "--",
 				"--disable-log-dump", "--repo-root=/kubernetes",
 				"--provider=", "--report-dir=", "--kubeconfig=",

--- a/test/conformance/image/go-runner/cmd_test.go
+++ b/test/conformance/image/go-runner/cmd_test.go
@@ -38,7 +38,7 @@ func TestGetCmd(t *testing.T) {
 			},
 			expectArgs: []string{
 				"ginkgobin",
-				"--focus=", "--skip=", " --seed=0",
+				"--focus=", "--skip=", "--seed=17",
 				"--noColor=true", "--timeout=24h", "testbin", "--",
 				"--disable-log-dump", "--repo-root=/kubernetes",
 				"--provider=", "--report-dir=", "--kubeconfig=",

--- a/test/conformance/image/go-runner/cmd_test.go
+++ b/test/conformance/image/go-runner/cmd_test.go
@@ -38,7 +38,7 @@ func TestGetCmd(t *testing.T) {
 			},
 			expectArgs: []string{
 				"ginkgobin",
-				"--focus=", "--skip=",
+				"--focus=", "--skip=", " --seed=0",
 				"--noColor=true", "--timeout=24h", "testbin", "--",
 				"--disable-log-dump", "--repo-root=/kubernetes",
 				"--provider=", "--report-dir=", "--kubeconfig=",

--- a/test/conformance/image/run_e2e.sh
+++ b/test/conformance/image/run_e2e.sh
@@ -68,6 +68,7 @@ ginkgo_args+=(
     "--focus=${E2E_FOCUS}"
     "--skip=${E2E_SKIP}"
     "--noColor=true"
+    "--seed=0"
 )
 
 set -x

--- a/test/conformance/image/run_e2e.sh
+++ b/test/conformance/image/run_e2e.sh
@@ -68,7 +68,7 @@ ginkgo_args+=(
     "--focus=${E2E_FOCUS}"
     "--skip=${E2E_SKIP}"
     "--noColor=true"
-    "--seed=0"
+    "--seed=17"
 )
 
 set -x

--- a/test/conformance/image/run_e2e.sh
+++ b/test/conformance/image/run_e2e.sh
@@ -68,7 +68,7 @@ ginkgo_args+=(
     "--focus=${E2E_FOCUS}"
     "--skip=${E2E_SKIP}"
     "--noColor=true"
-    "--seed=17"
+    "--seed=0"
 )
 
 set -x

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -49,7 +49,7 @@ import "github.com/onsi/ginkgo"
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-cluster-lifecycle] "+text, body)
+	return ginkgo.Describe("[sig-cluster-lifecycle] "+text, ginkgo.Ordered, body)
 }
 ```
 ```golang

--- a/test/e2e/apimachinery/custom_resource_definition.go
+++ b/test/e2e/apimachinery/custom_resource_definition.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/diff"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/client-go/dynamic"
@@ -83,6 +82,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 			labeled custom resource definitions.
 		*/
 		framework.ConformanceIt("listing custom resource definition objects works ", func(ctx context.Context) {
+			testCaseName := "listing custom resource definition objects works "
 			testListSize := 10
 			config, err := framework.LoadConfig()
 			framework.ExpectNoError(err, "loading config")
@@ -90,7 +90,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 			framework.ExpectNoError(err, "initializing apiExtensionClient")
 
 			// Label the CRDs we create so we can list only them even though they are cluster scoped
-			testUUID := string(uuid.NewUUID())
+			testUUID := framework.DeterministicTestCaseScopedId(testCaseName)
 
 			// Create CRD and wait for the resource to be recognized and available.
 			crds := make([]*v1.CustomResourceDefinition, testListSize)

--- a/test/e2e/apimachinery/framework.go
+++ b/test/e2e/apimachinery/framework.go
@@ -20,5 +20,5 @@ import "github.com/onsi/ginkgo/v2"
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-api-machinery] "+text, body)
+	return ginkgo.Describe("[sig-api-machinery] "+text, ginkgo.Ordered, ginkgo.Ordered, body)
 }

--- a/test/e2e/apimachinery/namespace.go
+++ b/test/e2e/apimachinery/namespace.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/util/retry"
@@ -271,7 +270,7 @@ var _ = SIGDescribe("Namespaces [Serial]", func() {
 	*/
 	framework.ConformanceIt("should patch a Namespace", func(ctx context.Context) {
 		ginkgo.By("creating a Namespace")
-		namespaceName := "nspatchtest-" + string(uuid.NewUUID())
+		namespaceName := "nspatchtest-" + framework.DeterministicNsSuffix("nspatchtest-")
 		ns, err := f.CreateNamespace(ctx, namespaceName, nil)
 		framework.ExpectNoError(err, "failed creating Namespace")
 		namespaceName = ns.ObjectMeta.Name

--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	clientset "k8s.io/client-go/kubernetes"
@@ -400,6 +399,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		create operation again and attempt to create an object; the webhook MUST deny the create.
 	*/
 	framework.ConformanceIt("patching/updating a validating webhook should work", func(ctx context.Context) {
+		testCaseName := "patching/updating a validating webhook should work"
 		client := f.ClientSet
 		admissionClient := client.AdmissionregistrationV1()
 
@@ -425,7 +425,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 
 		ginkgo.By("Creating a configMap that does not comply to the validation webhook rules")
 		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
-			cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
+			cm := namedNonCompliantConfigMap(framework.DeterministicTestCaseScopedId(testCaseName), f)
 			_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err == nil {
 				err = client.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, cm.Name, metav1.DeleteOptions{})
@@ -450,7 +450,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 
 		ginkgo.By("Creating a configMap that does not comply to the validation webhook rules")
 		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
-			cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
+			cm := namedNonCompliantConfigMap(framework.DeterministicTestCaseScopedId(testCaseName), f)
 			_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err != nil {
 				if !strings.Contains(err.Error(), "denied") {
@@ -472,7 +472,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 
 		ginkgo.By("Creating a configMap that does not comply to the validation webhook rules")
 		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
-			cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
+			cm := namedNonCompliantConfigMap(framework.DeterministicTestCaseScopedId(testCaseName), f)
 			_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err == nil {
 				err = client.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, cm.Name, metav1.DeleteOptions{})
@@ -497,6 +497,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 	framework.ConformanceIt("patching/updating a mutating webhook should work", func(ctx context.Context) {
 		client := f.ClientSet
 		admissionClient := client.AdmissionregistrationV1()
+		testCaseName := "patching/updating a mutating webhook should work"
 
 		ginkgo.By("Creating a mutating webhook configuration")
 		hook, err := createMutatingWebhookConfiguration(ctx, f, &admissionregistrationv1.MutatingWebhookConfiguration{
@@ -527,7 +528,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 
 		ginkgo.By("Creating a configMap that should not be mutated")
 		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
-			cm := namedToBeMutatedConfigMap(string(uuid.NewUUID()), f)
+			cm := namedToBeMutatedConfigMap(framework.DeterministicTestCaseScopedId(testCaseName), f)
 			created, err := client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err != nil {
 				return false, err
@@ -547,7 +548,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 
 		ginkgo.By("Creating a configMap that should be mutated")
 		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
-			cm := namedToBeMutatedConfigMap(string(uuid.NewUUID()), f)
+			cm := namedToBeMutatedConfigMap(framework.DeterministicTestCaseScopedId(testCaseName), f)
 			created, err := client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err != nil {
 				return false, err
@@ -570,7 +571,8 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 	*/
 	framework.ConformanceIt("listing validating webhooks should work", func(ctx context.Context) {
 		testListSize := 10
-		testUUID := string(uuid.NewUUID())
+		testCaseName := "listing validating webhooks should work"
+		testUUID := framework.DeterministicTestCaseScopedId(testCaseName)
 
 		for i := 0; i < testListSize; i++ {
 			name := fmt.Sprintf("%s-%d", f.UniqueName, i)
@@ -599,7 +601,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 
 		ginkgo.By("Creating a configMap that does not comply to the validation webhook rules")
 		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
-			cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
+			cm := namedNonCompliantConfigMap(framework.DeterministicTestCaseScopedId(testCaseName), f)
 			_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err == nil {
 				err = client.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, cm.Name, metav1.DeleteOptions{})
@@ -619,7 +621,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 
 		ginkgo.By("Creating a configMap that does not comply to the validation webhook rules")
 		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
-			cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
+			cm := namedNonCompliantConfigMap(framework.DeterministicTestCaseScopedId(testCaseName), f)
 			_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err != nil {
 				if !strings.Contains(err.Error(), "denied") {
@@ -644,7 +646,8 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 	*/
 	framework.ConformanceIt("listing mutating webhooks should work", func(ctx context.Context) {
 		testListSize := 10
-		testUUID := string(uuid.NewUUID())
+		testCaseName := "listing mutating webhooks should work"
+		testUUID := framework.DeterministicTestCaseScopedId(testCaseName)
 
 		for i := 0; i < testListSize; i++ {
 			name := fmt.Sprintf("%s-%d", f.UniqueName, i)
@@ -673,7 +676,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 
 		ginkgo.By("Creating a configMap that should be mutated")
 		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
-			cm := namedToBeMutatedConfigMap(string(uuid.NewUUID()), f)
+			cm := namedToBeMutatedConfigMap(framework.DeterministicTestCaseScopedId(testCaseName), f)
 			created, err := client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err != nil {
 				return false, err
@@ -691,7 +694,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 
 		ginkgo.By("Creating a configMap that should not be mutated")
 		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
-			cm := namedToBeMutatedConfigMap(string(uuid.NewUUID()), f)
+			cm := namedToBeMutatedConfigMap(framework.DeterministicTestCaseScopedId(testCaseName), f)
 			created, err := client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err != nil {
 				return false, err
@@ -2343,7 +2346,7 @@ func waitWebhookConfigurationReady(ctx context.Context, f *framework.Framework, 
 	return wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
 		marker := &v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: string(uuid.NewUUID()),
+				Name: framework.DeterministicNsSuffix(markersNamespaceName),
 				Labels: map[string]string{
 					f.UniqueName: "true",
 				},

--- a/test/e2e/apps/framework.go
+++ b/test/e2e/apps/framework.go
@@ -20,5 +20,5 @@ import "github.com/onsi/ginkgo/v2"
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-apps] "+text, body)
+	return ginkgo.Describe("[sig-apps] "+text, ginkgo.Ordered, body)
 }

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	watch "k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
@@ -483,7 +482,7 @@ func newRC(rsName string, replicas int32, rcPodLabels map[string]string, imageNa
 // the deployment of an image using a replication controller.
 // The image serves its hostname which is checked for each replica.
 func TestReplicationControllerServeImageOrFail(ctx context.Context, f *framework.Framework, test string, image string) {
-	name := "my-hostname-" + test + "-" + string(uuid.NewUUID())
+	name := "my-hostname-" + test + "-" + framework.DeterministicTestCaseScopedId("TestReplicationControllerServeImageOrFail"+"/"+"my-hostname-"+test+"-")
 	replicas := int32(1)
 
 	// Create a replication controller for a service

--- a/test/e2e/apps/replica_set.go
+++ b/test/e2e/apps/replica_set.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/controller/replicaset"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -181,7 +180,7 @@ var _ = SIGDescribe("ReplicaSet", func() {
 // A basic test to check the deployment of an image using a ReplicaSet. The
 // image serves its hostname which is checked for each replica.
 func testReplicaSetServeImageOrFail(ctx context.Context, f *framework.Framework, test string, image string) {
-	name := "my-hostname-" + test + "-" + string(uuid.NewUUID())
+	name := "my-hostname-" + test + "-" + framework.DeterministicTestCaseScopedId("testReplicaSetServeImageOrFail"+"/"+"my-hostname-"+test+"-")
 	replicas := int32(1)
 
 	// Create a ReplicaSet for a service that serves its hostname.

--- a/test/e2e/architecture/framework.go
+++ b/test/e2e/architecture/framework.go
@@ -20,5 +20,5 @@ import "github.com/onsi/ginkgo/v2"
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-architecture] "+text, body)
+	return ginkgo.Describe("[sig-architecture] "+text, ginkgo.Ordered, body)
 }

--- a/test/e2e/auth/framework.go
+++ b/test/e2e/auth/framework.go
@@ -20,5 +20,5 @@ import "github.com/onsi/ginkgo/v2"
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-auth] "+text, body)
+	return ginkgo.Describe("[sig-auth] "+text, ginkgo.Ordered, body)
 }

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -53,7 +53,8 @@ import (
 const rootCAConfigMapName = "kube-root-ca.crt"
 
 var _ = SIGDescribe("ServiceAccounts", func() {
-	f := framework.NewDefaultFramework("svcaccounts")
+	const frameworkName = "svcaccounts"
+	f := framework.NewDefaultFramework(frameworkName)
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
 
 	ginkgo.It("no secret-based service account token should be auto-generated", func(ctx context.Context) {
@@ -82,7 +83,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 		zero := int64(0)
 		pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "pod-service-account-" + string(uuid.NewUUID()),
+				Name: "pod-service-account-" + framework.DeterministicPodSuffix(frameworkName+"/"+"pod-service-account-"),
 			},
 			Spec: v1.PodSpec{
 				ServiceAccountName: sa.Name,
@@ -275,7 +276,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 	framework.ConformanceIt("should mount projected service account token", func(ctx context.Context) {
 
 		var (
-			podName         = "test-pod-" + string(uuid.NewUUID())
+			podName         = "test-pod-" + framework.DeterministicPodSuffix(frameworkName+"/"+"test-pod-")
 			volumeName      = "test-volume"
 			volumeMountPath = "/test-volume"
 			tokenVolumePath = "/test-volume/token"

--- a/test/e2e/autoscaling/framework.go
+++ b/test/e2e/autoscaling/framework.go
@@ -20,5 +20,5 @@ import "github.com/onsi/ginkgo/v2"
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-autoscaling] "+text, body)
+	return ginkgo.Describe("[sig-autoscaling] "+text, ginkgo.Ordered, body)
 }

--- a/test/e2e/cloud/framework.go
+++ b/test/e2e/cloud/framework.go
@@ -20,5 +20,5 @@ import "github.com/onsi/ginkgo/v2"
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-cloud-provider] "+text, body)
+	return ginkgo.Describe("[sig-cloud-provider] "+text, ginkgo.Ordered, body)
 }

--- a/test/e2e/cloud/gcp/apps/framework.go
+++ b/test/e2e/cloud/gcp/apps/framework.go
@@ -20,5 +20,5 @@ import "github.com/onsi/ginkgo/v2"
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-apps] "+text, body)
+	return ginkgo.Describe("[sig-apps] "+text, ginkgo.Ordered, body)
 }

--- a/test/e2e/cloud/gcp/auth/framework.go
+++ b/test/e2e/cloud/gcp/auth/framework.go
@@ -20,5 +20,5 @@ import "github.com/onsi/ginkgo/v2"
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-auth] "+text, body)
+	return ginkgo.Describe("[sig-auth] "+text, ginkgo.Ordered, body)
 }

--- a/test/e2e/cloud/gcp/framework.go
+++ b/test/e2e/cloud/gcp/framework.go
@@ -20,5 +20,5 @@ import "github.com/onsi/ginkgo/v2"
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-cloud-provider-gcp] "+text, body)
+	return ginkgo.Describe("[sig-cloud-provider-gcp] "+text, ginkgo.Ordered, body)
 }

--- a/test/e2e/cloud/gcp/network/framework.go
+++ b/test/e2e/cloud/gcp/network/framework.go
@@ -20,5 +20,5 @@ import "github.com/onsi/ginkgo/v2"
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-network] "+text, body)
+	return ginkgo.Describe("[sig-network] "+text, ginkgo.Ordered, body)
 }

--- a/test/e2e/cloud/gcp/node/framework.go
+++ b/test/e2e/cloud/gcp/node/framework.go
@@ -20,5 +20,5 @@ import "github.com/onsi/ginkgo/v2"
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-node] "+text, body)
+	return ginkgo.Describe("[sig-node] "+text, ginkgo.Ordered, body)
 }

--- a/test/e2e/common/network/framework.go
+++ b/test/e2e/common/network/framework.go
@@ -20,5 +20,5 @@ import "github.com/onsi/ginkgo/v2"
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-network] "+text, body)
+	return ginkgo.Describe("[sig-network] "+text, ginkgo.Ordered, body)
 }

--- a/test/e2e/common/node/configmap.go
+++ b/test/e2e/common/node/configmap.go
@@ -24,7 +24,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -34,7 +33,8 @@ import (
 )
 
 var _ = SIGDescribe("ConfigMap", func() {
-	f := framework.NewDefaultFramework("configmap")
+	const frameworkName = "configmap"
+	f := framework.NewDefaultFramework(frameworkName)
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
 
 	/*
@@ -43,7 +43,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 		Description: Create a Pod with an environment variable value set using a value from ConfigMap. A ConfigMap value MUST be accessible in the container environment.
 	*/
 	framework.ConformanceIt("should be consumable via environment variable [NodeConformance]", func(ctx context.Context) {
-		name := "configmap-test-" + string(uuid.NewUUID())
+		name := "configmap-test-" + framework.DeterministicTestCaseScopedId(frameworkName+"/"+"configmap-test-")
 		configMap := newConfigMap(f, name)
 		ginkgo.By(fmt.Sprintf("Creating configMap %v/%v", f.Namespace.Name, configMap.Name))
 		var err error
@@ -53,7 +53,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "pod-configmaps-" + string(uuid.NewUUID()),
+				Name: "pod-configmaps-" + framework.DeterministicPodSuffix(frameworkName+"/"+"pod-configmaps-"),
 			},
 			Spec: v1.PodSpec{
 				Containers: []v1.Container{
@@ -91,7 +91,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 		Description: Create a Pod with a environment source from ConfigMap. All ConfigMap values MUST be available as environment variables in the container.
 	*/
 	framework.ConformanceIt("should be consumable via the environment [NodeConformance]", func(ctx context.Context) {
-		name := "configmap-test-" + string(uuid.NewUUID())
+		name := "configmap-test-" + framework.DeterministicTestCaseScopedId(frameworkName+"/"+"configmap-test-")
 		configMap := newConfigMap(f, name)
 		ginkgo.By(fmt.Sprintf("Creating configMap %v/%v", f.Namespace.Name, configMap.Name))
 		var err error
@@ -101,7 +101,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "pod-configmaps-" + string(uuid.NewUUID()),
+				Name: "pod-configmaps-" + framework.DeterministicPodSuffix(frameworkName+"/"+"pod-configmaps-"),
 			},
 			Spec: v1.PodSpec{
 				Containers: []v1.Container{
@@ -141,7 +141,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 	})
 
 	ginkgo.It("should update ConfigMap successfully", func(ctx context.Context) {
-		name := "configmap-test-" + string(uuid.NewUUID())
+		name := "configmap-test-" + framework.DeterministicTestCaseScopedId(frameworkName+"/"+"configmap-test-")
 		configMap := newConfigMap(f, name)
 		ginkgo.By(fmt.Sprintf("Creating ConfigMap %v/%v", f.Namespace.Name, configMap.Name))
 		_, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configMap, metav1.CreateOptions{})
@@ -168,7 +168,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 	*/
 	framework.ConformanceIt("should run through a ConfigMap lifecycle", func(ctx context.Context) {
 		testNamespaceName := f.Namespace.Name
-		testConfigMapName := "test-configmap" + string(uuid.NewUUID())
+		testConfigMapName := "test-configmap" + framework.DeterministicTestCaseScopedId(frameworkName+"/"+"test-configmap")
 
 		testConfigMap := v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -258,7 +258,8 @@ func newConfigMap(f *framework.Framework, name string) *v1.ConfigMap {
 }
 
 func newConfigMapWithEmptyKey(ctx context.Context, f *framework.Framework) (*v1.ConfigMap, error) {
-	name := "configmap-test-emptyKey-" + string(uuid.NewUUID())
+	const frameworkName = "configmap"
+	name := "configmap-test-emptyKey-" + framework.DeterministicTestCaseScopedId(frameworkName+"/"+"configmap-test-emptyKey-")
 	configMap := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: f.Namespace.Name,

--- a/test/e2e/common/node/container.go
+++ b/test/e2e/common/node/container.go
@@ -24,8 +24,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 )
 
@@ -51,7 +51,8 @@ type ConformanceContainer struct {
 
 // Create creates the defined conformance container
 func (cc *ConformanceContainer) Create(ctx context.Context) {
-	cc.podName = cc.Container.Name + string(uuid.NewUUID())
+	// MYTODO: Container name can be duplicated for different test cases
+	cc.podName = framework.DeterministicPodSuffix(cc.Container.Name)
 	imagePullSecrets := []v1.LocalObjectReference{}
 	for _, s := range cc.ImagePullSecrets {
 		imagePullSecrets = append(imagePullSecrets, v1.LocalObjectReference{Name: s})

--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -823,7 +823,7 @@ func getRestartCount(p *v1.Pod) int {
 
 func testWebServerPodSpec(readinessProbe, livenessProbe *v1.Probe, containerName string, port int) *v1.Pod {
 	return &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-webserver-" + string(uuid.NewUUID())},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-webserver-" + framework.DeterministicPodSuffix("testWebServerPodSpec"+"/"+"test-webserver-")},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{
@@ -842,7 +842,7 @@ func testWebServerPodSpec(readinessProbe, livenessProbe *v1.Probe, containerName
 func busyBoxPodSpec(readinessProbe, livenessProbe *v1.Probe, cmd []string) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "busybox-" + string(uuid.NewUUID()),
+			Name:   "busybox-" + framework.DeterministicPodSuffix("busyBoxPodSpec"+"/"+"test-webserver-"),
 			Labels: map[string]string{"test": "liveness"},
 		},
 		Spec: v1.PodSpec{
@@ -860,7 +860,7 @@ func busyBoxPodSpec(readinessProbe, livenessProbe *v1.Probe, cmd []string) *v1.P
 }
 
 func livenessPodSpec(namespace string, readinessProbe, livenessProbe *v1.Probe) *v1.Pod {
-	pod := e2epod.NewAgnhostPod(namespace, "liveness-"+string(uuid.NewUUID()), nil, nil, nil, "liveness")
+	pod := e2epod.NewAgnhostPod(namespace, "liveness-"+framework.DeterministicPodSuffix("livenessPodSpec"+"/"+"liveness-"), nil, nil, nil, "liveness")
 	pod.ObjectMeta.Labels = map[string]string{"test": "liveness"}
 	pod.Spec.Containers[0].LivenessProbe = livenessProbe
 	pod.Spec.Containers[0].ReadinessProbe = readinessProbe
@@ -870,7 +870,7 @@ func livenessPodSpec(namespace string, readinessProbe, livenessProbe *v1.Probe) 
 func startupPodSpec(startupProbe, readinessProbe, livenessProbe *v1.Probe, cmd []string) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "startup-" + string(uuid.NewUUID()),
+			Name:   "startup-" + framework.DeterministicPodSuffix("startupPodSpec"+"/"+"startup-"),
 			Labels: map[string]string{"test": "startup"},
 		},
 		Spec: v1.PodSpec{
@@ -1036,7 +1036,7 @@ func runReadinessFailTest(ctx context.Context, f *framework.Framework, pod *v1.P
 
 func gRPCServerPodSpec(readinessProbe, livenessProbe *v1.Probe, containerName string) *v1.Pod {
 	return &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-grpc-" + string(uuid.NewUUID())},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-grpc-" + framework.DeterministicPodSuffix("gRPCServerPodSpec"+"/"+"test-grpc-")},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{

--- a/test/e2e/common/node/containers.go
+++ b/test/e2e/common/node/containers.go
@@ -22,7 +22,6 @@ import (
 	"github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
@@ -98,7 +97,8 @@ var _ = SIGDescribe("Containers", func() {
 
 // Return a prototypical entrypoint test pod
 func entrypointTestPod(namespace string, entrypointArgs ...string) *v1.Pod {
-	podName := "client-containers-" + string(uuid.NewUUID())
+	const frameworkName = "containers"
+	podName := "client-containers-" + framework.DeterministicPodSuffix(frameworkName+"/"+"client-containers-")
 	pod := e2epod.NewAgnhostPod(namespace, podName, nil, nil, nil, entrypointArgs...)
 
 	one := int64(1)

--- a/test/e2e/common/node/downwardapi.go
+++ b/test/e2e/common/node/downwardapi.go
@@ -34,7 +34,8 @@ import (
 )
 
 var _ = SIGDescribe("Downward API", func() {
-	f := framework.NewDefaultFramework("downward-api")
+	const frameworkName = "downward-api"
+	f := framework.NewDefaultFramework("frameworkName")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
 	/*
@@ -43,7 +44,7 @@ var _ = SIGDescribe("Downward API", func() {
 	   Description: Downward API MUST expose Pod and Container fields as environment variables. Specify Pod Name, namespace and IP as environment variable in the Pod Spec are visible at runtime in the container.
 	*/
 	framework.ConformanceIt("should provide pod name, namespace and IP address as env vars [NodeConformance]", func(ctx context.Context) {
-		podName := "downward-api-" + string(uuid.NewUUID())
+		podName := "downward-api-" + framework.DeterministicPodSuffix(frameworkName+"/"+"downward-api-")
 		env := []v1.EnvVar{
 			{
 				Name: "POD_NAME",
@@ -89,7 +90,7 @@ var _ = SIGDescribe("Downward API", func() {
 	   Description: Downward API MUST expose Pod and Container fields as environment variables. Specify host IP as environment variable in the Pod Spec are visible at runtime in the container.
 	*/
 	framework.ConformanceIt("should provide host IP as an env var [NodeConformance]", func(ctx context.Context) {
-		podName := "downward-api-" + string(uuid.NewUUID())
+		podName := "downward-api-" + framework.DeterministicPodSuffix(frameworkName+"/"+"downward-api-")
 		env := []v1.EnvVar{
 			{
 				Name: "HOST_IP",
@@ -110,7 +111,7 @@ var _ = SIGDescribe("Downward API", func() {
 	})
 
 	ginkgo.It("should provide host IP and pod IP as an env var if pod uses host network [LinuxOnly]", func(ctx context.Context) {
-		podName := "downward-api-" + string(uuid.NewUUID())
+		podName := "downward-api-" + framework.DeterministicPodSuffix(frameworkName+"/"+"downward-api-")
 		env := []v1.EnvVar{
 			{
 				Name: "HOST_IP",
@@ -165,7 +166,7 @@ var _ = SIGDescribe("Downward API", func() {
 	   Description: Downward API MUST expose CPU request and Memory request set through environment variables at runtime in the container.
 	*/
 	framework.ConformanceIt("should provide container's limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance]", func(ctx context.Context) {
-		podName := "downward-api-" + string(uuid.NewUUID())
+		podName := "downward-api-" + framework.DeterministicPodSuffix(frameworkName+"/"+"downward-api-")
 		env := []v1.EnvVar{
 			{
 				Name: "CPU_LIMIT",
@@ -216,7 +217,7 @@ var _ = SIGDescribe("Downward API", func() {
 	   Description: Downward API MUST expose CPU request and Memory limits set through environment variables at runtime in the container.
 	*/
 	framework.ConformanceIt("should provide default limits.cpu/memory from node allocatable [NodeConformance]", func(ctx context.Context) {
-		podName := "downward-api-" + string(uuid.NewUUID())
+		podName := "downward-api-" + framework.DeterministicPodSuffix(frameworkName+"/"+"downward-api-")
 		env := []v1.EnvVar{
 			{
 				Name: "CPU_LIMIT",
@@ -266,7 +267,7 @@ var _ = SIGDescribe("Downward API", func() {
 	   Description: Downward API MUST expose Pod UID set through environment variables at runtime in the container.
 	*/
 	framework.ConformanceIt("should provide pod UID as env vars [NodeConformance]", func(ctx context.Context) {
-		podName := "downward-api-" + string(uuid.NewUUID())
+		podName := "downward-api-" + framework.DeterministicPodSuffix(frameworkName+"/"+"downward-api-")
 		env := []v1.EnvVar{
 			{
 				Name: "POD_UID",

--- a/test/e2e/common/node/expansion.go
+++ b/test/e2e/common/node/expansion.go
@@ -21,7 +21,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
@@ -384,7 +383,7 @@ func testPodFailSubpath(ctx context.Context, f *framework.Framework, pod *v1.Pod
 }
 
 func newPod(command []string, envVars []v1.EnvVar, mounts []v1.VolumeMount, volumes []v1.Volume) *v1.Pod {
-	podName := "var-expansion-" + string(uuid.NewUUID())
+	podName := "var-expansion-" + framework.DeterministicPodSuffix("var-expansion-")
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   podName,

--- a/test/e2e/common/node/framework.go
+++ b/test/e2e/common/node/framework.go
@@ -20,5 +20,5 @@ import "github.com/onsi/ginkgo/v2"
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-node] "+text, body)
+	return ginkgo.Describe("[sig-node] "+text, ginkgo.Ordered, body)
 }

--- a/test/e2e/common/node/init_container.go
+++ b/test/e2e/common/node/init_container.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 	watchtools "k8s.io/client-go/tools/watch"
@@ -159,7 +158,8 @@ func initContainersInvariants(pod *v1.Pod) error {
 }
 
 var _ = SIGDescribe("InitContainer [NodeConformance]", func() {
-	f := framework.NewDefaultFramework("init-container")
+	const frameworkName = "init-container"
+	f := framework.NewDefaultFramework(frameworkName)
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
 	var podClient *e2epod.PodClient
 	ginkgo.BeforeEach(func() {
@@ -176,7 +176,7 @@ var _ = SIGDescribe("InitContainer [NodeConformance]", func() {
 	*/
 	framework.ConformanceIt("should invoke init containers on a RestartNever pod", func(ctx context.Context) {
 		ginkgo.By("creating the pod")
-		name := "pod-init-" + string(uuid.NewUUID())
+		name := "pod-init-" + framework.DeterministicPodSuffix(frameworkName+"/"+"pod-init-")
 		value := strconv.Itoa(time.Now().Nanosecond())
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -254,7 +254,7 @@ var _ = SIGDescribe("InitContainer [NodeConformance]", func() {
 	*/
 	framework.ConformanceIt("should invoke init containers on a RestartAlways pod", func(ctx context.Context) {
 		ginkgo.By("creating the pod")
-		name := "pod-init-" + string(uuid.NewUUID())
+		name := "pod-init-" + framework.DeterministicPodSuffix(frameworkName+"/"+"pod-init-")
 		value := strconv.Itoa(time.Now().Nanosecond())
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -333,7 +333,7 @@ var _ = SIGDescribe("InitContainer [NodeConformance]", func() {
 	*/
 	framework.ConformanceIt("should not start app containers if init containers fail on a RestartAlways pod", func(ctx context.Context) {
 		ginkgo.By("creating the pod")
-		name := "pod-init-" + string(uuid.NewUUID())
+		name := "pod-init-" + framework.DeterministicPodSuffix(frameworkName+"/"+"pod-init-")
 		value := strconv.Itoa(time.Now().Nanosecond())
 
 		pod := &v1.Pod{
@@ -457,7 +457,7 @@ var _ = SIGDescribe("InitContainer [NodeConformance]", func() {
 	*/
 	framework.ConformanceIt("should not start app containers and fail the pod if init containers fail on a RestartNever pod", func(ctx context.Context) {
 		ginkgo.By("creating the pod")
-		name := "pod-init-" + string(uuid.NewUUID())
+		name := "pod-init-" + framework.DeterministicPodSuffix(frameworkName+"/"+"pod-init-")
 		value := strconv.Itoa(time.Now().Nanosecond())
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/common/node/kubelet.go
+++ b/test/e2e/common/node/kubelet.go
@@ -42,7 +42,8 @@ var _ = SIGDescribe("Kubelet", func() {
 		podClient = e2epod.NewPodClient(f)
 	})
 	ginkgo.Context("when scheduling a busybox command in a pod", func() {
-		podName := "busybox-scheduling-" + string(uuid.NewUUID())
+		podName := "busybox-scheduling-" + framework.DeterministicPodSuffix("busybox-scheduling-")
+		podName2 := "busybox-scheduling-" + framework.DeterministicPodSuffix("busybox-scheduling-")
 
 		/*
 			Release: v1.13
@@ -88,7 +89,7 @@ var _ = SIGDescribe("Kubelet", func() {
 			fmt.Printf("test logging by takurosato\n")
 			podClient.CreateSync(ctx, &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: podName,
+					Name: podName2,
 				},
 				Spec: v1.PodSpec{
 					// Don't restart the Pod since it is expected to exit
@@ -96,7 +97,7 @@ var _ = SIGDescribe("Kubelet", func() {
 					Containers: []v1.Container{
 						{
 							Image:   framework.BusyBoxImage,
-							Name:    podName,
+							Name:    podName2,
 							Command: []string{"sh", "-c", "echo 'Hello World' ; sleep 240"},
 						},
 					},
@@ -104,7 +105,7 @@ var _ = SIGDescribe("Kubelet", func() {
 			})
 			gomega.Eventually(ctx, func() string {
 				sinceTime := metav1.NewTime(time.Now().Add(time.Duration(-1 * time.Hour)))
-				rc, err := podClient.GetLogs(podName, &v1.PodLogOptions{SinceTime: &sinceTime}).Stream(ctx)
+				rc, err := podClient.GetLogs(podName2, &v1.PodLogOptions{SinceTime: &sinceTime}).Stream(ctx)
 				if err != nil {
 					return ""
 				}

--- a/test/e2e/common/node/kubelet.go
+++ b/test/e2e/common/node/kubelet.go
@@ -43,7 +43,6 @@ var _ = SIGDescribe("Kubelet", func() {
 	})
 	ginkgo.Context("when scheduling a busybox command in a pod", func() {
 		podName := "busybox-scheduling-" + framework.DeterministicPodSuffix("busybox-scheduling-")
-		podName2 := "busybox-scheduling-" + framework.DeterministicPodSuffix("busybox-scheduling-")
 
 		/*
 			Release: v1.13
@@ -80,41 +79,6 @@ var _ = SIGDescribe("Kubelet", func() {
 			}, time.Minute, time.Second*4).Should(gomega.Equal("Hello World\n"))
 		})
 
-		/*
-			Release: v1.13
-			Testname: Kubelet, log output, default
-			Description: By default the stdout and stderr from the process being executed in a pod MUST be sent to the pod's logs.
-		*/
-		framework.ConformanceIt("extract conformance test", func(ctx context.Context) {
-			fmt.Printf("test logging by takurosato\n")
-			podClient.CreateSync(ctx, &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: podName2,
-				},
-				Spec: v1.PodSpec{
-					// Don't restart the Pod since it is expected to exit
-					RestartPolicy: v1.RestartPolicyNever,
-					Containers: []v1.Container{
-						{
-							Image:   framework.BusyBoxImage,
-							Name:    podName2,
-							Command: []string{"sh", "-c", "echo 'Hello World' ; sleep 240"},
-						},
-					},
-				},
-			})
-			gomega.Eventually(ctx, func() string {
-				sinceTime := metav1.NewTime(time.Now().Add(time.Duration(-1 * time.Hour)))
-				rc, err := podClient.GetLogs(podName2, &v1.PodLogOptions{SinceTime: &sinceTime}).Stream(ctx)
-				if err != nil {
-					return ""
-				}
-				defer rc.Close()
-				buf := new(bytes.Buffer)
-				buf.ReadFrom(rc)
-				return buf.String()
-			}, time.Minute, time.Second*4).Should(gomega.Equal("Hello World\n"))
-		})
 	})
 	ginkgo.Context("when scheduling a busybox command that always fails in a pod", func() {
 		var podName string

--- a/test/e2e/common/node/kubelet.go
+++ b/test/e2e/common/node/kubelet.go
@@ -25,7 +25,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -35,6 +34,7 @@ import (
 )
 
 var _ = SIGDescribe("Kubelet", func() {
+	const frameworkName = "kubelet-test"
 	f := framework.NewDefaultFramework("kubelet-test")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
 	var podClient *e2epod.PodClient
@@ -42,7 +42,7 @@ var _ = SIGDescribe("Kubelet", func() {
 		podClient = e2epod.NewPodClient(f)
 	})
 	ginkgo.Context("when scheduling a busybox command in a pod", func() {
-		podName := "busybox-scheduling-" + framework.DeterministicPodSuffix("busybox-scheduling-")
+		podName := "busybox-scheduling-" + framework.DeterministicPodSuffix(frameworkName+"/"+"busybox-scheduling-")
 
 		/*
 			Release: v1.13
@@ -84,7 +84,7 @@ var _ = SIGDescribe("Kubelet", func() {
 		var podName string
 
 		ginkgo.BeforeEach(func(ctx context.Context) {
-			podName = "bin-false" + string(uuid.NewUUID())
+			podName = "bin-false" + framework.DeterministicPodSuffix(frameworkName+"/"+"bin-false")
 			podClient.Create(ctx, &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: podName,
@@ -139,7 +139,7 @@ var _ = SIGDescribe("Kubelet", func() {
 		})
 	})
 	ginkgo.Context("when scheduling an agnhost Pod with hostAliases", func() {
-		podName := "agnhost-host-aliases" + string(uuid.NewUUID())
+		podName := "agnhost-host-aliases" + framework.DeterministicPodSuffix(frameworkName+"/"+"agnhost-host-aliases")
 
 		/*
 			Release: v1.13
@@ -174,7 +174,7 @@ var _ = SIGDescribe("Kubelet", func() {
 		})
 	})
 	ginkgo.Context("when scheduling a read only busybox container", func() {
-		podName := "busybox-readonly-fs" + string(uuid.NewUUID())
+		podName := "busybox-readonly-fs" + framework.DeterministicPodSuffix(frameworkName+"/"+"busybox-readonly-fs")
 
 		/*
 			Release: v1.13

--- a/test/e2e/common/node/pods.go
+++ b/test/e2e/common/node/pods.go
@@ -40,7 +40,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
@@ -187,7 +186,8 @@ func expectNoErrorWithRetries(fn func() error, maxRetries int, explain ...interf
 }
 
 var _ = SIGDescribe("Pods", func() {
-	f := framework.NewDefaultFramework("pods")
+	const frameworkName = "pods"
+	f := framework.NewDefaultFramework(frameworkName)
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelRestricted
 	var podClient *e2epod.PodClient
 	var dc dynamic.Interface
@@ -203,7 +203,7 @@ var _ = SIGDescribe("Pods", func() {
 		Description: Create a Pod. Pod status MUST return successfully and contains a valid IP address.
 	*/
 	framework.ConformanceIt("should get a host IP [NodeConformance]", func(ctx context.Context) {
-		name := "pod-hostip-" + string(uuid.NewUUID())
+		name := "pod-hostip-" + framework.DeterministicPodSuffix(frameworkName+"/"+"pod-hostip-")
 		testHostIP(ctx, podClient, e2epod.MustMixinRestrictedPodSecurity(&v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
@@ -226,7 +226,7 @@ var _ = SIGDescribe("Pods", func() {
 	*/
 	framework.ConformanceIt("should be submitted and removed [NodeConformance]", func(ctx context.Context) {
 		ginkgo.By("creating the pod")
-		name := "pod-submit-remove-" + string(uuid.NewUUID())
+		name := "pod-submit-remove-" + framework.DeterministicPodSuffix(frameworkName+"/"+"pod-submit-remove-")
 		value := strconv.Itoa(time.Now().Nanosecond())
 		pod := e2epod.MustMixinRestrictedPodSecurity(&v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -344,7 +344,7 @@ var _ = SIGDescribe("Pods", func() {
 	*/
 	framework.ConformanceIt("should be updated [NodeConformance]", func(ctx context.Context) {
 		ginkgo.By("creating the pod")
-		name := "pod-update-" + string(uuid.NewUUID())
+		name := "pod-update-" + framework.DeterministicPodSuffix(frameworkName+"/"+"pod-update-")
 		value := strconv.Itoa(time.Now().Nanosecond())
 		pod := e2epod.MustMixinRestrictedPodSecurity(&v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -398,7 +398,7 @@ var _ = SIGDescribe("Pods", func() {
 	*/
 	framework.ConformanceIt("should allow activeDeadlineSeconds to be updated [NodeConformance]", func(ctx context.Context) {
 		ginkgo.By("creating the pod")
-		name := "pod-update-activedeadlineseconds-" + string(uuid.NewUUID())
+		name := "pod-update-activedeadlineseconds-" + framework.DeterministicPodSuffix(frameworkName+"/"+"pod-update-activedeadlineseconds-")
 		value := strconv.Itoa(time.Now().Nanosecond())
 		pod := e2epod.MustMixinRestrictedPodSecurity(&v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -445,7 +445,7 @@ var _ = SIGDescribe("Pods", func() {
 	framework.ConformanceIt("should contain environment variables for services [NodeConformance]", func(ctx context.Context) {
 		// Make a pod that will be a service.
 		// This pod serves its hostname via HTTP.
-		serverName := "server-envvars-" + string(uuid.NewUUID())
+		serverName := "server-envvars-" + framework.DeterministicPodSuffix(frameworkName+"/"+"server-envvars-")
 		serverPod := e2epod.MustMixinRestrictedPodSecurity(&v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   serverName,
@@ -492,7 +492,7 @@ var _ = SIGDescribe("Pods", func() {
 		framework.ExpectNoError(err, "failed to create service")
 
 		// Make a client pod that verifies that it has the service environment variables.
-		podName := "client-envvars-" + string(uuid.NewUUID())
+		podName := "client-envvars-" + framework.DeterministicPodSuffix(frameworkName+"/"+"client-envvars-")
 		const containerName = "env3cont"
 		pod := e2epod.MustMixinRestrictedPodSecurity(&v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -539,7 +539,7 @@ var _ = SIGDescribe("Pods", func() {
 		framework.ExpectNoError(err, "unable to get base config")
 
 		ginkgo.By("creating the pod")
-		name := "pod-exec-websocket-" + string(uuid.NewUUID())
+		name := "pod-exec-websocket-" + framework.DeterministicPodSuffix(frameworkName+"/"+"pod-exec-websocket-")
 		pod := e2epod.MustMixinRestrictedPodSecurity(&v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
@@ -621,7 +621,7 @@ var _ = SIGDescribe("Pods", func() {
 		framework.ExpectNoError(err, "unable to get base config")
 
 		ginkgo.By("creating the pod")
-		name := "pod-logs-websocket-" + string(uuid.NewUUID())
+		name := "pod-logs-websocket-" + framework.DeterministicPodSuffix(frameworkName+"/"+"pod-logs-websocket-")
 		pod := e2epod.MustMixinRestrictedPodSecurity(&v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,

--- a/test/e2e/common/node/podtemplates.go
+++ b/test/e2e/common/node/podtemplates.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -42,6 +41,7 @@ const (
 )
 
 var _ = SIGDescribe("PodTemplates", func() {
+	const frameworkName = "podtemplate"
 	f := framework.NewDefaultFramework("podtemplate")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	/*
@@ -52,7 +52,7 @@ var _ = SIGDescribe("PodTemplates", func() {
 	*/
 	framework.ConformanceIt("should run the lifecycle of PodTemplates", func(ctx context.Context) {
 		testNamespaceName := f.Namespace.Name
-		podTemplateName := "nginx-pod-template-" + string(uuid.NewUUID())
+		podTemplateName := "nginx-pod-template-" + framework.DeterministicPodSuffix(frameworkName+"/"+"nginx-pod-template-")
 
 		// get a list of PodTemplates (in all namespaces to hit endpoint)
 		podTemplateList, err := f.ClientSet.CoreV1().PodTemplates("").List(ctx, metav1.ListOptions{

--- a/test/e2e/common/node/secrets.go
+++ b/test/e2e/common/node/secrets.go
@@ -27,7 +27,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -35,6 +34,7 @@ import (
 )
 
 var _ = SIGDescribe("Secrets", func() {
+	const frameworkName = "secrets"
 	f := framework.NewDefaultFramework("secrets")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
 
@@ -44,7 +44,7 @@ var _ = SIGDescribe("Secrets", func() {
 		Description: Create a secret. Create a Pod with Container that declares a environment variable which references the secret created to extract a key value from the secret. Pod MUST have the environment variable that contains proper value for the key to the secret.
 	*/
 	framework.ConformanceIt("should be consumable from pods in env vars [NodeConformance]", func(ctx context.Context) {
-		name := "secret-test-" + string(uuid.NewUUID())
+		name := "secret-test-" + framework.DeterministicTestCaseScopedId(frameworkName+"/"+"secret-test-")
 		secret := secretForTest(f.Namespace.Name, name)
 
 		ginkgo.By(fmt.Sprintf("Creating secret with name %s", secret.Name))
@@ -55,7 +55,7 @@ var _ = SIGDescribe("Secrets", func() {
 
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "pod-secrets-" + string(uuid.NewUUID()),
+				Name: "pod-secrets-" + framework.DeterministicPodSuffix(frameworkName+"/"+"pod-secrets-"),
 			},
 			Spec: v1.PodSpec{
 				Containers: []v1.Container{
@@ -93,7 +93,7 @@ var _ = SIGDescribe("Secrets", func() {
 		Description: Create a secret. Create a Pod with Container that declares a environment variable using 'EnvFrom' which references the secret created to extract a key value from the secret. Pod MUST have the environment variable that contains proper value for the key to the secret.
 	*/
 	framework.ConformanceIt("should be consumable via the environment [NodeConformance]", func(ctx context.Context) {
-		name := "secret-test-" + string(uuid.NewUUID())
+		name := "secret-test-" + framework.DeterministicTestCaseScopedId(frameworkName+"/"+"secret-test-")
 		secret := secretForTest(f.Namespace.Name, name)
 		ginkgo.By(fmt.Sprintf("creating secret %v/%v", f.Namespace.Name, secret.Name))
 		var err error
@@ -103,7 +103,7 @@ var _ = SIGDescribe("Secrets", func() {
 
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "pod-configmaps-" + string(uuid.NewUUID()),
+				Name: "pod-configmaps-" + framework.DeterministicPodSuffix(frameworkName+"/"+"pod-configmaps-"),
 			},
 			Spec: v1.PodSpec{
 				Containers: []v1.Container{
@@ -154,7 +154,7 @@ var _ = SIGDescribe("Secrets", func() {
 	framework.ConformanceIt("should patch a secret", func(ctx context.Context) {
 		ginkgo.By("creating a secret")
 
-		secretTestName := "test-secret-" + string(uuid.NewUUID())
+		secretTestName := "test-secret-" + framework.DeterministicTestCaseScopedId(frameworkName+"/"+"test-secret-")
 
 		// create a secret in the test namespace
 		_, err := f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, &v1.Secret{
@@ -254,7 +254,7 @@ func secretForTest(namespace, name string) *v1.Secret {
 }
 
 func createEmptyKeySecretForTest(ctx context.Context, f *framework.Framework) (*v1.Secret, error) {
-	secretName := "secret-emptykey-test-" + string(uuid.NewUUID())
+	secretName := "secret-emptykey-test-" + framework.DeterministicTestCaseScopedId("createEmptyKeySecretForTest"+"/"+"secret-emptykey-test-")
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: f.Namespace.Name,

--- a/test/e2e/common/node/security_context.go
+++ b/test/e2e/common/node/security_context.go
@@ -44,6 +44,7 @@ var (
 )
 
 var _ = SIGDescribe("Security Context", func() {
+	const frameworkName = "security-context-test"
 	f := framework.NewDefaultFramework("security-context-test")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	var podClient *e2epod.PodClient
@@ -56,7 +57,7 @@ var _ = SIGDescribe("Security Context", func() {
 		makePod := func(hostUsers bool) *v1.Pod {
 			return &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "userns-" + string(uuid.NewUUID()),
+					Name: "userns-" + framework.DeterministicPodSuffix(frameworkName+"/"+"userns-"),
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
@@ -328,7 +329,8 @@ var _ = SIGDescribe("Security Context", func() {
 			}
 		}
 		createAndWaitUserPod := func(ctx context.Context, userid int64) {
-			podName := fmt.Sprintf("busybox-user-%d-%s", userid, uuid.NewUUID())
+			suffix := framework.DeterministicPodSuffix(frameworkName + "/" + fmt.Sprintf("busybox-user-%d-", userid))
+			podName := fmt.Sprintf("busybox-user-%d-%s", userid, suffix)
 			podClient.Create(ctx, makeUserPod(podName,
 				framework.BusyBoxImage,
 				[]string{"sh", "-c", fmt.Sprintf("test $(id -u) -eq %d", userid)},
@@ -449,7 +451,8 @@ var _ = SIGDescribe("Security Context", func() {
 			}
 		}
 		createAndWaitUserPod := func(ctx context.Context, readOnlyRootFilesystem bool) string {
-			podName := fmt.Sprintf("busybox-readonly-%v-%s", readOnlyRootFilesystem, uuid.NewUUID())
+			suffix := framework.DeterministicPodSuffix(frameworkName + "/" + fmt.Sprintf("busybox-readonly-%v-", readOnlyRootFilesystem))
+			podName := fmt.Sprintf("busybox-readonly-%v-%s", readOnlyRootFilesystem, suffix)
 			podClient.Create(ctx, makeUserPod(podName,
 				framework.BusyBoxImage,
 				[]string{"sh", "-c", "touch checkfile"},
@@ -510,7 +513,8 @@ var _ = SIGDescribe("Security Context", func() {
 			}
 		}
 		createAndWaitUserPod := func(ctx context.Context, privileged bool) string {
-			podName := fmt.Sprintf("busybox-privileged-%v-%s", privileged, uuid.NewUUID())
+			suffix := framework.DeterministicPodSuffix(frameworkName + "/" + fmt.Sprintf("busybox-privileged-%v-", privileged))
+			podName := fmt.Sprintf("busybox-privileged-%v-%s", privileged, suffix)
 			podClient.Create(ctx, makeUserPod(podName,
 				framework.BusyBoxImage,
 				[]string{"sh", "-c", "ip link add dummy0 type dummy || true"},
@@ -607,7 +611,7 @@ var _ = SIGDescribe("Security Context", func() {
 			[LinuxOnly]: This test is marked LinuxOnly since Windows does not support running as UID / GID, or privilege escalation.
 		*/
 		framework.ConformanceIt("should not allow privilege escalation when false [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
-			podName := "alpine-nnp-false-" + string(uuid.NewUUID())
+			podName := "alpine-nnp-false-" + framework.DeterministicPodSuffix(frameworkName+"/"+"alpine-nnp-false-")
 			apeFalse := false
 			if err := createAndMatchOutput(ctx, podName, fmt.Sprintf("Effective uid: %d", nonRootTestUserID), &apeFalse, nonRootTestUserID); err != nil {
 				framework.Failf("Match output for pod %q failed: %v", podName, err)

--- a/test/e2e/common/node/sysctl.go
+++ b/test/e2e/common/node/sysctl.go
@@ -21,7 +21,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
@@ -39,12 +38,13 @@ var _ = SIGDescribe("Sysctls [LinuxOnly] [NodeConformance]", func() {
 		e2eskipper.SkipIfNodeOSDistroIs("windows")
 	})
 
+	const frameworkName = "sysctl"
 	f := framework.NewDefaultFramework("sysctl")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	var podClient *e2epod.PodClient
 
 	testPod := func() *v1.Pod {
-		podName := "sysctl-" + string(uuid.NewUUID())
+		podName := "sysctl-" + framework.DeterministicPodSuffix(frameworkName+"/"+"sysctl-")
 		pod := v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        podName,

--- a/test/e2e/common/storage/configmap_volume.go
+++ b/test/e2e/common/storage/configmap_volume.go
@@ -26,7 +26,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
@@ -36,7 +35,8 @@ import (
 )
 
 var _ = SIGDescribe("ConfigMap", func() {
-	f := framework.NewDefaultFramework("configmap")
+	const frameworkName = "configmap"
+	f := framework.NewDefaultFramework(frameworkName)
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
 
 	/*
@@ -125,7 +125,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 		podLogTimeout := e2epod.GetPodSecretUpdateTimeout(ctx, f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 
-		name := "configmap-test-upd-" + string(uuid.NewUUID())
+		name := "configmap-test-upd-" + framework.DeterministicTestCaseScopedId(frameworkName+"/"+"configmap-test-upd-")
 		volumeName := "configmap-volume"
 		volumeMountPath := "/etc/configmap-volume"
 
@@ -176,7 +176,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 		podLogTimeout := e2epod.GetPodSecretUpdateTimeout(ctx, f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 
-		name := "configmap-test-upd-" + string(uuid.NewUUID())
+		name := "configmap-test-upd-" + framework.DeterministicTestCaseScopedId(frameworkName+"/"+"configmap-test-upd-")
 		volumeName := "configmap-volume"
 		volumeMountPath := "/etc/configmap-volume"
 		containerName := "configmap-volume-binary-test"
@@ -243,7 +243,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 		trueVal := true
 		volumeMountPath := "/etc/configmap-volumes"
 
-		deleteName := "cm-test-opt-del-" + string(uuid.NewUUID())
+		deleteName := "cm-test-opt-del-" + framework.DeterministicTestCaseScopedId(frameworkName+"/"+"cm-test-opt-del-")
 		deleteContainerName := "delcm-volume-test"
 		deleteVolumeName := "deletecm-volume"
 		deleteConfigMap := &v1.ConfigMap{
@@ -256,7 +256,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 			},
 		}
 
-		updateName := "cm-test-opt-upd-" + string(uuid.NewUUID())
+		updateName := "cm-test-opt-upd-" + framework.DeterministicTestCaseScopedId(frameworkName+"/"+"cm-test-opt-upd-")
 		updateContainerName := "updcm-volume-test"
 		updateVolumeName := "updatecm-volume"
 		updateConfigMap := &v1.ConfigMap{
@@ -269,7 +269,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 			},
 		}
 
-		createName := "cm-test-opt-create-" + string(uuid.NewUUID())
+		createName := "cm-test-opt-create-" + framework.DeterministicTestCaseScopedId(frameworkName+"/"+"cm-test-opt-create-")
 		createContainerName := "createcm-volume-test"
 		createVolumeName := "createcm-volume"
 		createConfigMap := &v1.ConfigMap{
@@ -295,7 +295,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "pod-configmaps-" + string(uuid.NewUUID()),
+				Name: "pod-configmaps-" + framework.DeterministicPodSuffix(frameworkName+"/"+"pod-configmaps-"),
 			},
 			Spec: v1.PodSpec{
 				Volumes: []v1.Volume{
@@ -422,7 +422,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 	*/
 	framework.ConformanceIt("should be consumable in multiple volumes in the same pod [NodeConformance]", func(ctx context.Context) {
 		var (
-			name             = "configmap-test-volume-" + string(uuid.NewUUID())
+			name             = "configmap-test-volume-" + framework.DeterministicTestCaseScopedId(frameworkName+"/"+"configmap-test-volume-")
 			volumeName       = "configmap-volume"
 			volumeMountPath  = "/etc/configmap-volume"
 			volumeName2      = "configmap-volume-2"
@@ -438,7 +438,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "pod-configmaps-" + string(uuid.NewUUID()),
+				Name: "pod-configmaps-" + framework.DeterministicPodSuffix(frameworkName+"/"+"pod-configmaps-"),
 			},
 			Spec: v1.PodSpec{
 				Volumes: []v1.Volume{
@@ -590,7 +590,7 @@ func doConfigMapE2EWithoutMappings(ctx context.Context, f *framework.Framework, 
 	groupID := int64(fsGroup)
 
 	var (
-		name            = "configmap-test-volume-" + string(uuid.NewUUID())
+		name            = "configmap-test-volume-" + framework.DeterministicTestCaseScopedId("doConfigMapE2EWithoutMappings"+"/"+"configmap-test-volume-")
 		volumeName      = "configmap-volume"
 		volumeMountPath = "/etc/configmap-volume"
 		configMap       = newConfigMap(f, name)
@@ -631,7 +631,7 @@ func doConfigMapE2EWithMappings(ctx context.Context, f *framework.Framework, asU
 	groupID := int64(fsGroup)
 
 	var (
-		name            = "configmap-test-volume-map-" + string(uuid.NewUUID())
+		name            = "configmap-test-volume-map-" + framework.DeterministicTestCaseScopedId("doConfigMapE2EWithMappings"+"/"+"configmap-test-volume-map-")
 		volumeName      = "configmap-volume"
 		volumeMountPath = "/etc/configmap-volume"
 		configMap       = newConfigMap(f, name)
@@ -684,7 +684,7 @@ func createNonOptionalConfigMapPod(ctx context.Context, f *framework.Framework, 
 	containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 	falseValue := false
 
-	createName := "cm-test-opt-create-" + string(uuid.NewUUID())
+	createName := "cm-test-opt-create-" + framework.DeterministicTestCaseScopedId("createNonOptionalConfigMapPod"+"/"+"cm-test-opt-create-")
 	createVolumeName := "createcm-volume"
 
 	// creating a pod without configMap object created, by mentioning the configMap volume source's local reference name
@@ -702,7 +702,7 @@ func createNonOptionalConfigMapPodWithConfig(ctx context.Context, f *framework.F
 	containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 	falseValue := false
 
-	createName := "cm-test-opt-create-" + string(uuid.NewUUID())
+	createName := "cm-test-opt-create-" + framework.DeterministicTestCaseScopedId("createNonOptionalConfigMapPodWithConfig"+"/"+"cm-test-opt-create-")
 	createVolumeName := "createcm-volume"
 	configMap := newConfigMap(f, createName)
 
@@ -740,7 +740,8 @@ func createConfigMapVolumeMounttestPod(namespace, volumeName, referenceName, mou
 			},
 		},
 	}
-	podName := "pod-configmaps-" + string(uuid.NewUUID())
+	const frameworkName = "configmap"
+	podName := "pod-configmaps-" + framework.DeterministicPodSuffix(frameworkName+"/"+"pod-configmaps-")
 	mounttestArgs = append([]string{"mounttest"}, mounttestArgs...)
 	pod := e2epod.NewAgnhostPod(namespace, podName, volumes, createMounts(volumeName, mountPath, true), nil, mounttestArgs...)
 	pod.Spec.RestartPolicy = v1.RestartPolicyNever

--- a/test/e2e/common/storage/downwardapi_volume.go
+++ b/test/e2e/common/storage/downwardapi_volume.go
@@ -39,6 +39,7 @@ import (
 var _ = SIGDescribe("Downward API volume", func() {
 	// How long to wait for a log pod to be displayed
 	const podLogTimeout = 3 * time.Minute
+	const frameworkName = "downward-api"
 	f := framework.NewDefaultFramework("downward-api")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
 	var podClient *e2epod.PodClient
@@ -52,7 +53,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains a item for the Pod name. The container runtime MUST be able to access Pod name from the specified path on the mounted volume.
 	*/
 	framework.ConformanceIt("should provide podname only [NodeConformance]", func(ctx context.Context) {
-		podName := "downwardapi-volume-" + string(uuid.NewUUID())
+		podName := "downwardapi-volume-" + framework.DeterministicPodSuffix(frameworkName+"/"+"downwardapi-volume-")
 		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podinfo/podname")
 
 		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
@@ -67,7 +68,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
 	framework.ConformanceIt("should set DefaultMode on files [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
-		podName := "downwardapi-volume-" + string(uuid.NewUUID())
+		podName := "downwardapi-volume-" + framework.DeterministicPodSuffix(frameworkName+"/"+"downwardapi-volume-")
 		defaultMode := int32(0400)
 		pod := downwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", nil, &defaultMode)
 
@@ -83,7 +84,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
 	framework.ConformanceIt("should set mode on item file [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
-		podName := "downwardapi-volume-" + string(uuid.NewUUID())
+		podName := "downwardapi-volume-" + framework.DeterministicPodSuffix(frameworkName+"/"+"downwardapi-volume-")
 		mode := int32(0400)
 		pod := downwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", &mode, nil)
 
@@ -133,7 +134,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 		labels["key1"] = "value1"
 		labels["key2"] = "value2"
 
-		podName := "labelsupdate" + string(uuid.NewUUID())
+		podName := "labelsupdate" + framework.DeterministicPodSuffix(frameworkName+"/"+"labelsupdate")
 		pod := downwardAPIVolumePodForUpdateTest(podName, labels, map[string]string{}, "/etc/podinfo/labels")
 		containerName := "client-container"
 		ginkgo.By("Creating the pod")
@@ -163,7 +164,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 	framework.ConformanceIt("should update annotations on modification [NodeConformance]", func(ctx context.Context) {
 		annotations := map[string]string{}
 		annotations["builder"] = "bar"
-		podName := "annotationupdate" + string(uuid.NewUUID())
+		podName := "annotationupdate" + framework.DeterministicPodSuffix(frameworkName+"/"+"annotationupdate")
 		pod := downwardAPIVolumePodForUpdateTest(podName, map[string]string{}, annotations, "/etc/podinfo/annotations")
 
 		containerName := "client-container"
@@ -192,7 +193,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains a item for the CPU limits. The container runtime MUST be able to access CPU limits from the specified path on the mounted volume.
 	*/
 	framework.ConformanceIt("should provide container's cpu limit [NodeConformance]", func(ctx context.Context) {
-		podName := "downwardapi-volume-" + string(uuid.NewUUID())
+		podName := "downwardapi-volume-" + framework.DeterministicPodSuffix(frameworkName+"/"+"downwardapi-volume-")
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/cpu_limit")
 
 		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
@@ -206,7 +207,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains a item for the memory limits. The container runtime MUST be able to access memory limits from the specified path on the mounted volume.
 	*/
 	framework.ConformanceIt("should provide container's memory limit [NodeConformance]", func(ctx context.Context) {
-		podName := "downwardapi-volume-" + string(uuid.NewUUID())
+		podName := "downwardapi-volume-" + framework.DeterministicPodSuffix(frameworkName+"/"+"downwardapi-volume-")
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_limit")
 
 		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
@@ -220,7 +221,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains a item for the CPU request. The container runtime MUST be able to access CPU request from the specified path on the mounted volume.
 	*/
 	framework.ConformanceIt("should provide container's cpu request [NodeConformance]", func(ctx context.Context) {
-		podName := "downwardapi-volume-" + string(uuid.NewUUID())
+		podName := "downwardapi-volume-" + framework.DeterministicPodSuffix(frameworkName+"/"+"downwardapi-volume-")
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/cpu_request")
 
 		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
@@ -234,7 +235,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains a item for the memory request. The container runtime MUST be able to access memory request from the specified path on the mounted volume.
 	*/
 	framework.ConformanceIt("should provide container's memory request [NodeConformance]", func(ctx context.Context) {
-		podName := "downwardapi-volume-" + string(uuid.NewUUID())
+		podName := "downwardapi-volume-" + framework.DeterministicPodSuffix(frameworkName+"/"+"downwardapi-volume-")
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_request")
 
 		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
@@ -248,7 +249,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains a item for the CPU limits. CPU limits is not specified for the container. The container runtime MUST be able to access CPU limits from the specified path on the mounted volume and the value MUST be default node allocatable.
 	*/
 	framework.ConformanceIt("should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance]", func(ctx context.Context) {
-		podName := "downwardapi-volume-" + string(uuid.NewUUID())
+		podName := "downwardapi-volume-" + framework.DeterministicPodSuffix(frameworkName+"/"+"downwardapi-volume-")
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/podinfo/cpu_limit")
 
 		e2epodoutput.TestContainerOutputRegexp(ctx, f, "downward API volume plugin", pod, 0, []string{"[1-9]"})
@@ -260,7 +261,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains a item for the memory limits. memory limits is not specified for the container. The container runtime MUST be able to access memory limits from the specified path on the mounted volume and the value MUST be default node allocatable.
 	*/
 	framework.ConformanceIt("should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance]", func(ctx context.Context) {
-		podName := "downwardapi-volume-" + string(uuid.NewUUID())
+		podName := "downwardapi-volume-" + framework.DeterministicPodSuffix(frameworkName+"/"+"downwardapi-volume-")
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/podinfo/memory_limit")
 
 		e2epodoutput.TestContainerOutputRegexp(ctx, f, "downward API volume plugin", pod, 0, []string{"[1-9]"})

--- a/test/e2e/common/storage/empty_dir.go
+++ b/test/e2e/common/storage/empty_dir.go
@@ -238,9 +238,10 @@ var _ = SIGDescribe("EmptyDir volumes", func() {
 			deletionGracePeriod        = int64(0)
 		)
 
+		const frameworkName = "emptydir"
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "pod-sharedvolume-" + string(uuid.NewUUID()),
+				Name: "pod-sharedvolume-" + framework.DeterministicPodSuffix(frameworkName+"/"+"pod-sharedvolume-"),
 			},
 			Spec: v1.PodSpec{
 				Volumes: []v1.Volume{
@@ -588,7 +589,8 @@ func formatMedium(medium v1.StorageMedium) string {
 // testPodWithVolume creates a Pod that runs as the given UID and with the given empty dir source mounted at the given path.
 // If the uid is 0, the Pod will run as its default user (root).
 func testPodWithVolume(uid int64, path string, source *v1.EmptyDirVolumeSource) *v1.Pod {
-	podName := "pod-" + string(uuid.NewUUID())
+	const frameworkName = "emptydir"
+	podName := "pod-" + framework.DeterministicPodSuffix(frameworkName+"/"+"pod-")
 	pod := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",

--- a/test/e2e/common/storage/framework.go
+++ b/test/e2e/common/storage/framework.go
@@ -20,5 +20,5 @@ import "github.com/onsi/ginkgo/v2"
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-storage] "+text, body)
+	return ginkgo.Describe("[sig-storage] "+text, ginkgo.Ordered, body)
 }

--- a/test/e2e/common/storage/projected_combined.go
+++ b/test/e2e/common/storage/projected_combined.go
@@ -22,7 +22,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -32,6 +31,7 @@ import (
 )
 
 var _ = SIGDescribe("Projected combined", func() {
+	const frameworkName = "projected"
 	f := framework.NewDefaultFramework("projected")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
 
@@ -43,9 +43,10 @@ var _ = SIGDescribe("Projected combined", func() {
 	*/
 	framework.ConformanceIt("should project all components that make up the projection API [Projection][NodeConformance]", func(ctx context.Context) {
 		var err error
-		podName := "projected-volume-" + string(uuid.NewUUID())
-		secretName := "secret-projected-all-test-volume-" + string(uuid.NewUUID())
-		configMapName := "configmap-projected-all-test-volume-" + string(uuid.NewUUID())
+		suffix := framework.DeterministicPodSuffix(frameworkName + "/" + "projected-volume-")
+		podName := "projected-volume-" + suffix
+		secretName := "secret-projected-all-test-volume-" + suffix
+		configMapName := "configmap-projected-all-test-volume-" + suffix
 		configMap := &v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: f.Namespace.Name,

--- a/test/e2e/common/storage/projected_configmap.go
+++ b/test/e2e/common/storage/projected_configmap.go
@@ -23,7 +23,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
@@ -36,6 +35,7 @@ import (
 )
 
 var _ = SIGDescribe("Projected configMap", func() {
+	const frameworkName = "projected"
 	f := framework.NewDefaultFramework("projected")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
 
@@ -125,7 +125,7 @@ var _ = SIGDescribe("Projected configMap", func() {
 		podLogTimeout := e2epod.GetPodSecretUpdateTimeout(ctx, f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 
-		name := "projected-configmap-test-upd-" + string(uuid.NewUUID())
+		name := "projected-configmap-test-upd-" + framework.DeterministicPodSuffix(frameworkName+"/"+"projected-configmap-test-upd-")
 		volumeName := "projected-configmap-volume"
 		volumeMountPath := "/etc/projected-configmap-volume"
 		configMap := &v1.ConfigMap{
@@ -177,7 +177,7 @@ var _ = SIGDescribe("Projected configMap", func() {
 		trueVal := true
 		volumeMountPath := "/etc/projected-configmap-volumes"
 
-		deleteName := "cm-test-opt-del-" + string(uuid.NewUUID())
+		deleteName := "cm-test-opt-del-" + framework.DeterministicPodSuffix("cm-test-opt-del-")
 		deleteContainerName := "delcm-volume-test"
 		deleteVolumeName := "deletecm-volume"
 		deleteConfigMap := &v1.ConfigMap{
@@ -190,7 +190,7 @@ var _ = SIGDescribe("Projected configMap", func() {
 			},
 		}
 
-		updateName := "cm-test-opt-upd-" + string(uuid.NewUUID())
+		updateName := "cm-test-opt-upd-" + framework.DeterministicPodSuffix(frameworkName+"/"+"cm-test-opt-upd-")
 		updateContainerName := "updcm-volume-test"
 		updateVolumeName := "updatecm-volume"
 		updateConfigMap := &v1.ConfigMap{
@@ -203,7 +203,7 @@ var _ = SIGDescribe("Projected configMap", func() {
 			},
 		}
 
-		createName := "cm-test-opt-create-" + string(uuid.NewUUID())
+		createName := "cm-test-opt-create-" + framework.DeterministicPodSuffix(frameworkName+"/"+"cm-test-opt-create-")
 		createContainerName := "createcm-volume-test"
 		createVolumeName := "createcm-volume"
 		createConfigMap := &v1.ConfigMap{
@@ -229,7 +229,7 @@ var _ = SIGDescribe("Projected configMap", func() {
 
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "pod-projected-configmaps-" + string(uuid.NewUUID()),
+				Name: "pod-projected-configmaps-" + framework.DeterministicPodSuffix(frameworkName+"/"+"pod-projected-configmaps-"),
 			},
 			Spec: v1.PodSpec{
 				Volumes: []v1.Volume{
@@ -374,7 +374,7 @@ var _ = SIGDescribe("Projected configMap", func() {
 	*/
 	framework.ConformanceIt("should be consumable in multiple volumes in the same pod [NodeConformance]", func(ctx context.Context) {
 		var (
-			name             = "projected-configmap-test-volume-" + string(uuid.NewUUID())
+			name             = "projected-configmap-test-volume-" + framework.DeterministicPodSuffix(frameworkName+"/"+"projected-configmap-test-volume-")
 			volumeName       = "projected-configmap-volume"
 			volumeMountPath  = "/etc/projected-configmap-volume"
 			volumeName2      = "projected-configmap-volume-2"
@@ -390,7 +390,7 @@ var _ = SIGDescribe("Projected configMap", func() {
 
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "pod-projected-configmaps-" + string(uuid.NewUUID()),
+				Name: "pod-projected-configmaps-" + framework.DeterministicPodSuffix(frameworkName+"/"+"pod-projected-configmaps-"),
 			},
 			Spec: v1.PodSpec{
 				Volumes: []v1.Volume{
@@ -480,9 +480,10 @@ var _ = SIGDescribe("Projected configMap", func() {
 
 func doProjectedConfigMapE2EWithoutMappings(ctx context.Context, f *framework.Framework, asUser bool, fsGroup int64, defaultMode *int32) {
 	groupID := int64(fsGroup)
+	const frameworkName = "projected"
 
 	var (
-		name            = "projected-configmap-test-volume-" + string(uuid.NewUUID())
+		name            = "projected-configmap-test-volume-" + framework.DeterministicPodSuffix(frameworkName+"/"+"projected-configmap-test-volume-")
 		volumeName      = "projected-configmap-volume"
 		volumeMountPath = "/etc/projected-configmap-volume"
 		configMap       = newConfigMap(f, name)
@@ -520,9 +521,10 @@ func doProjectedConfigMapE2EWithoutMappings(ctx context.Context, f *framework.Fr
 
 func doProjectedConfigMapE2EWithMappings(ctx context.Context, f *framework.Framework, asUser bool, fsGroup int64, itemMode *int32) {
 	groupID := int64(fsGroup)
+	const frameworkName = "projected"
 
 	var (
-		name            = "projected-configmap-test-volume-map-" + string(uuid.NewUUID())
+		name            = "projected-configmap-test-volume-map-" + framework.DeterministicPodSuffix(frameworkName+"/"+"projected-configmap-test-volume-map-")
 		volumeName      = "projected-configmap-volume"
 		volumeMountPath = "/etc/projected-configmap-volume"
 		configMap       = newConfigMap(f, name)
@@ -588,7 +590,8 @@ func createProjectedConfigMapMounttestPod(namespace, volumeName, referenceName, 
 			},
 		},
 	}
-	podName := "pod-projected-configmaps-" + string(uuid.NewUUID())
+	const frameworkName = "projected"
+	podName := "pod-projected-configmaps-" + framework.DeterministicPodSuffix(frameworkName+"/"+"pod-projected-configmaps-")
 	mounttestArgs = append([]string{"mounttest"}, mounttestArgs...)
 	pod := e2epod.NewAgnhostPod(namespace, podName, volumes, createMounts(volumeName, mountPath, true), nil, mounttestArgs...)
 	pod.Spec.RestartPolicy = v1.RestartPolicyNever

--- a/test/e2e/common/storage/projected_downwardapi.go
+++ b/test/e2e/common/storage/projected_downwardapi.go
@@ -52,7 +52,7 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests. Pod MUST be able to read the pod name from the mounted DownwardAPIVolumeFiles.
 	*/
 	framework.ConformanceIt("should provide podname only [NodeConformance]", func(ctx context.Context) {
-		podName := "downwardapi-volume-" + string(uuid.NewUUID())
+		podName := "downwardapi-volume-" + framework.DeterministicPodSuffix("projected2"+"/"+"downwardapi-volume-")
 		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podinfo/podname")
 
 		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
@@ -67,7 +67,7 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 	   This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
 	framework.ConformanceIt("should set DefaultMode on files [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
-		podName := "downwardapi-volume-" + string(uuid.NewUUID())
+		podName := "downwardapi-volume-" + framework.DeterministicPodSuffix("projected2"+"/"+"downwardapi-volume-")
 		defaultMode := int32(0400)
 		pod := projectedDownwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", nil, &defaultMode)
 
@@ -83,7 +83,7 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 	   This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
 	framework.ConformanceIt("should set mode on item file [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
-		podName := "downwardapi-volume-" + string(uuid.NewUUID())
+		podName := "downwardapi-volume-" + framework.DeterministicPodSuffix("projected2"+"/"+"downwardapi-volume-")
 		mode := int32(0400)
 		pod := projectedDownwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", &mode, nil)
 
@@ -133,7 +133,7 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 		labels["key1"] = "value1"
 		labels["key2"] = "value2"
 
-		podName := "labelsupdate" + string(uuid.NewUUID())
+		podName := "labelsupdate" + framework.DeterministicPodSuffix("projected2"+"/"+"labelsupdate")
 		pod := projectedDownwardAPIVolumePodForUpdateTest(podName, labels, map[string]string{}, "/etc/podinfo/labels")
 		containerName := "client-container"
 		ginkgo.By("Creating the pod")
@@ -163,7 +163,7 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 	framework.ConformanceIt("should update annotations on modification [NodeConformance]", func(ctx context.Context) {
 		annotations := map[string]string{}
 		annotations["builder"] = "bar"
-		podName := "annotationupdate" + string(uuid.NewUUID())
+		podName := "annotationupdate" + framework.DeterministicPodSuffix("projected2"+"/"+"annotationupdate")
 		pod := projectedDownwardAPIVolumePodForUpdateTest(podName, map[string]string{}, annotations, "/etc/podinfo/annotations")
 
 		containerName := "client-container"
@@ -192,7 +192,7 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests. Pod MUST be able to read the cpu limits from the mounted DownwardAPIVolumeFiles.
 	*/
 	framework.ConformanceIt("should provide container's cpu limit [NodeConformance]", func(ctx context.Context) {
-		podName := "downwardapi-volume-" + string(uuid.NewUUID())
+		podName := "downwardapi-volume-" + framework.DeterministicPodSuffix("projected2"+"/"+"downwardapi-volume-")
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/cpu_limit")
 
 		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
@@ -206,7 +206,7 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests. Pod MUST be able to read the memory limits from the mounted DownwardAPIVolumeFiles.
 	*/
 	framework.ConformanceIt("should provide container's memory limit [NodeConformance]", func(ctx context.Context) {
-		podName := "downwardapi-volume-" + string(uuid.NewUUID())
+		podName := "downwardapi-volume-" + framework.DeterministicPodSuffix("projected2"+"/"+"downwardapi-volume-")
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_limit")
 
 		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
@@ -220,7 +220,7 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests. Pod MUST be able to read the cpu request from the mounted DownwardAPIVolumeFiles.
 	*/
 	framework.ConformanceIt("should provide container's cpu request [NodeConformance]", func(ctx context.Context) {
-		podName := "downwardapi-volume-" + string(uuid.NewUUID())
+		podName := "downwardapi-volume-" + framework.DeterministicPodSuffix("projected2"+"/"+"downwardapi-volume-")
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/cpu_request")
 
 		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
@@ -234,7 +234,7 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests. Pod MUST be able to read the memory request from the mounted DownwardAPIVolumeFiles.
 	*/
 	framework.ConformanceIt("should provide container's memory request [NodeConformance]", func(ctx context.Context) {
-		podName := "downwardapi-volume-" + string(uuid.NewUUID())
+		podName := "downwardapi-volume-" + framework.DeterministicPodSuffix("projected2"+"/"+"downwardapi-volume-")
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_request")
 
 		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
@@ -248,7 +248,7 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests.  The CPU and memory resources for requests and limits are NOT specified for the container. Pod MUST be able to read the default cpu limits from the mounted DownwardAPIVolumeFiles.
 	*/
 	framework.ConformanceIt("should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance]", func(ctx context.Context) {
-		podName := "downwardapi-volume-" + string(uuid.NewUUID())
+		podName := "downwardapi-volume-" + framework.DeterministicPodSuffix("projected2"+"/"+"downwardapi-volume-")
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/podinfo/cpu_limit")
 
 		e2epodoutput.TestContainerOutputRegexp(ctx, f, "downward API volume plugin", pod, 0, []string{"[1-9]"})
@@ -260,7 +260,7 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests.  The CPU and memory resources for requests and limits are NOT specified for the container. Pod MUST be able to read the default memory limits from the mounted DownwardAPIVolumeFiles.
 	*/
 	framework.ConformanceIt("should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance]", func(ctx context.Context) {
-		podName := "downwardapi-volume-" + string(uuid.NewUUID())
+		podName := "downwardapi-volume-" + framework.DeterministicPodSuffix("projected2"+"/"+"downwardapi-volume-")
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/podinfo/memory_limit")
 
 		e2epodoutput.TestContainerOutputRegexp(ctx, f, "downward API volume plugin", pod, 0, []string{"[1-9]"})

--- a/test/e2e/framework/pod/create.go
+++ b/test/e2e/framework/pod/create.go
@@ -23,8 +23,8 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
@@ -170,7 +170,7 @@ func MakeSecPod(podConfig *Config) (*v1.Pod, error) {
 		podConfig.Command = "trap exit TERM; while true; do sleep 1; done"
 	}
 
-	podName := "pod-" + string(uuid.NewUUID())
+	podName := "pod-" + framework.DeterministicPodSuffix(podConfig.NS+"/"+"pod-")
 	if podConfig.FsGroup == nil && !NodeOSDistroIs("windows") {
 		podConfig.FsGroup = func(i int64) *int64 {
 			return &i

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -336,10 +336,12 @@ func CreateTestingNS(ctx context.Context, baseName string, c clientset.Interface
 	}
 	labels["e2e-run"] = string(RunID)
 
+	labels["extract-policy"] = "1"
+
 	// We don't use ObjectMeta.GenerateName feature, as in case of API call
 	// failure we don't know whether the namespace was created and what is its
 	// name.
-	name := fmt.Sprintf("%v-%v", baseName, RandomSuffix())
+	name := fmt.Sprintf("%v-%v", baseName, DeterministicNsSuffix(baseName)) // editing
 
 	namespaceObj := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -551,7 +553,7 @@ func DeterministicNsSuffix(prefix string) string {
 var podSuffixCounter = NewCounter()
 
 func DeterministicPodSuffix(prefix string) string {
-	return strconv.Itoa(nsSuffixCounter.Increment(prefix))
+	return strconv.Itoa(podSuffixCounter.Increment(prefix))
 }
 
 // StartCmdAndStreamOutput returns stdout and stderr after starting the given cmd.

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -556,6 +556,12 @@ func DeterministicPodSuffix(prefix string) string {
 	return strconv.Itoa(podSuffixCounter.Increment(prefix))
 }
 
+var TestCaseScopedIdCounter = NewCounter()
+
+func DeterministicTestCaseScopedId(prefix string) string {
+	return strconv.Itoa(TestCaseScopedIdCounter.Increment(prefix))
+}
+
 // StartCmdAndStreamOutput returns stdout and stderr after starting the given cmd.
 func StartCmdAndStreamOutput(cmd *exec.Cmd) (stdout, stderr io.ReadCloser, err error) {
 	stdout, err = cmd.StdoutPipe()

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -358,7 +358,7 @@ func CreateTestingNS(ctx context.Context, baseName string, c clientset.Interface
 			if apierrors.IsAlreadyExists(err) {
 				// regenerate on conflict
 				Logf("Namespace name %q was already taken, generate a new name and retry", namespaceObj.Name)
-				namespaceObj.Name = fmt.Sprintf("%v-%v", baseName, RandomSuffix())
+				namespaceObj.Name = fmt.Sprintf("%v-%v", baseName, DeterministicNsSuffix(baseName)) // editing
 			} else {
 				Logf("Unexpected error while creating namespace: %v", err)
 			}
@@ -521,6 +521,37 @@ func LoadClientset() (*clientset.Clientset, error) {
 // RandomSuffix provides a random sequence to append to pods,services,rcs.
 func RandomSuffix() string {
 	return strconv.Itoa(rand.Intn(10000))
+}
+
+type Counter struct {
+	counters map[string]int
+	mutex    sync.Mutex
+}
+
+func NewCounter() *Counter {
+	return &Counter{
+		counters: make(map[string]int),
+	}
+}
+
+func (cm *Counter) Increment(name string) int {
+	cm.mutex.Lock()
+	defer cm.mutex.Unlock()
+
+	cm.counters[name]++
+	return cm.counters[name]
+}
+
+var nsSuffixCounter = NewCounter()
+
+func DeterministicNsSuffix(prefix string) string {
+	return strconv.Itoa(nsSuffixCounter.Increment(prefix))
+}
+
+var podSuffixCounter = NewCounter()
+
+func DeterministicPodSuffix(prefix string) string {
+	return strconv.Itoa(nsSuffixCounter.Increment(prefix))
 }
 
 // StartCmdAndStreamOutput returns stdout and stderr after starting the given cmd.

--- a/test/e2e/instrumentation/common/framework.go
+++ b/test/e2e/instrumentation/common/framework.go
@@ -20,5 +20,5 @@ import "github.com/onsi/ginkgo/v2"
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-instrumentation] "+text, body)
+	return ginkgo.Describe("[sig-instrumentation] "+text, ginkgo.Ordered, body)
 }

--- a/test/e2e/kubectl/framework.go
+++ b/test/e2e/kubectl/framework.go
@@ -20,5 +20,5 @@ import "github.com/onsi/ginkgo/v2"
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-cli] "+text, body)
+	return ginkgo.Describe("[sig-cli] "+text, ginkgo.Ordered, body)
 }

--- a/test/e2e/kubectl/logs.go
+++ b/test/e2e/kubectl/logs.go
@@ -26,7 +26,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubectl/pkg/cmd/util/podcmd"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -163,7 +162,7 @@ var _ = SIGDescribe("Kubectl logs", func() {
 	ginkgo.Describe("default container logs", func() {
 		ginkgo.Describe("the second container is the default-container by annotation", func() {
 			var pod *v1.Pod
-			podName := "pod" + string(uuid.NewUUID())
+			podName := "pod" + framework.DeterministicTestCaseScopedId("the second container is the default-container by annotation")
 			defaultContainerName := "container-2"
 			ginkgo.BeforeEach(func(ctx context.Context) {
 				podClient := f.ClientSet.CoreV1().Pods(ns)

--- a/test/e2e/lifecycle/framework.go
+++ b/test/e2e/lifecycle/framework.go
@@ -20,5 +20,5 @@ import "github.com/onsi/ginkgo/v2"
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-cluster-lifecycle] "+text, body)
+	return ginkgo.Describe("[sig-cluster-lifecycle] "+text, ginkgo.Ordered, body)
 }

--- a/test/e2e/network/common/framework.go
+++ b/test/e2e/network/common/framework.go
@@ -20,5 +20,5 @@ import "github.com/onsi/ginkgo/v2"
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-network] "+text, body)
+	return ginkgo.Describe("[sig-network] "+text, ginkgo.Ordered, body)
 }

--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -197,7 +196,7 @@ func (t *dnsTestCommon) restoreDNSConfigMap(ctx context.Context, configMapData m
 func (t *dnsTestCommon) createUtilPodLabel(ctx context.Context, baseName string) {
 	// Actual port # doesn't matter, just needs to exist.
 	const servicePort = 10101
-	podName := fmt.Sprintf("%s-%s", baseName, string(uuid.NewUUID()))
+	podName := fmt.Sprintf("%s-%s", baseName, framework.DeterministicPodSuffix("createUtilPodLabel"+"/"+baseName))
 	ports := []v1.ContainerPort{{ContainerPort: servicePort, Protocol: v1.ProtocolTCP}}
 	t.utilPod = e2epod.NewAgnhostPod(t.f.Namespace.Name, podName, nil, nil, ports)
 
@@ -258,7 +257,7 @@ func (t *dnsTestCommon) deleteCoreDNSPods(ctx context.Context) {
 }
 
 func generateCoreDNSServerPod(corednsConfig *v1.ConfigMap) *v1.Pod {
-	podName := fmt.Sprintf("e2e-configmap-dns-server-%s", string(uuid.NewUUID()))
+	podName := fmt.Sprintf("e2e-configmap-dns-server-%s", framework.DeterministicPodSuffix("generateCoreDNSServerPod"+"/"+"e2e-configmap-dns-server-"))
 	volumes := []v1.Volume{
 		{
 			Name: "coredns-config",
@@ -353,7 +352,7 @@ func (t *dnsTestCommon) deleteDNSServerPod(ctx context.Context) {
 }
 
 func createDNSPod(namespace, wheezyProbeCmd, jessieProbeCmd, podHostName, serviceName string) *v1.Pod {
-	podName := "dns-test-" + string(uuid.NewUUID())
+	podName := "dns-test-" + framework.DeterministicPodSuffix("createDNSPod"+"/"+"dns-test-")
 	volumes := []v1.Volume{
 		{
 			Name: "results",

--- a/test/e2e/node/framework.go
+++ b/test/e2e/node/framework.go
@@ -20,5 +20,5 @@ import "github.com/onsi/ginkgo/v2"
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-node] "+text, body)
+	return ginkgo.Describe("[sig-node] "+text, ginkgo.Ordered, body)
 }

--- a/test/e2e/node/security_context.go
+++ b/test/e2e/node/security_context.go
@@ -28,7 +28,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -41,7 +40,7 @@ import (
 )
 
 func scTestPod(hostIPC bool, hostPID bool) *v1.Pod {
-	podName := "security-context-" + string(uuid.NewUUID())
+	podName := "security-context-" + framework.DeterministicPodSuffix("scTestPod"+"/"+"security-context-")
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        podName,

--- a/test/e2e/scheduling/framework.go
+++ b/test/e2e/scheduling/framework.go
@@ -37,7 +37,7 @@ var (
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-scheduling] "+text, body)
+	return ginkgo.Describe("[sig-scheduling] "+text, ginkgo.Ordered, body)
 }
 
 // WaitForStableCluster waits until all existing pods are scheduled and returns their amount.

--- a/test/e2e/scheduling/nvidia-gpus.go
+++ b/test/e2e/scheduling/nvidia-gpus.go
@@ -26,7 +26,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	extensionsinternal "k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2edebug "k8s.io/kubernetes/test/e2e/framework/debug"
@@ -57,7 +56,7 @@ var (
 )
 
 func makeCudaAdditionDevicePluginTestPod() *v1.Pod {
-	podName := testPodNamePrefix + string(uuid.NewUUID())
+	podName := testPodNamePrefix + framework.DeterministicPodSuffix("makeCudaAdditionDevicePluginTestPod"+"/"+testPodNamePrefix)
 	testPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: podName,

--- a/test/e2e/storage/utils/framework.go
+++ b/test/e2e/storage/utils/framework.go
@@ -20,5 +20,5 @@ import "github.com/onsi/ginkgo/v2"
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-storage] "+text, body)
+	return ginkgo.Describe("[sig-storage] "+text, ginkgo.Ordered, body)
 }

--- a/test/e2e/windows/hybrid_network.go
+++ b/test/e2e/windows/hybrid_network.go
@@ -135,6 +135,7 @@ func windowsCheck(address string) []string {
 
 func createTestPod(f *framework.Framework, image string, os string) *v1.Pod {
 	containerName := fmt.Sprintf("%s-container", os)
+	// MEMO: It's not used in conformance test
 	podName := "pod-" + string(uuid.NewUUID())
 	pod := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{

--- a/test/e2e/windows/kubelet_stats.go
+++ b/test/e2e/windows/kubelet_stats.go
@@ -236,6 +236,7 @@ func newKubeletStatsTestPods(numPods int, image imageutils.Config, nodeName stri
 	var pods []*v1.Pod
 
 	for i := 0; i < numPods; i++ {
+		// MEMO: It's not used in conformance test
 		podName := "statscollectiontest-" + string(uuid.NewUUID())
 		pod := v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/windows/memory_limits.go
+++ b/test/e2e/windows/memory_limits.go
@@ -110,6 +110,7 @@ func overrideAllocatableMemoryTest(ctx context.Context, f *framework.Framework, 
 
 	for _, node := range nodeList.Items {
 		status := node.Status
+		// MEMO: not used in conformance test
 		podName := "mem-test-" + string(uuid.NewUUID())
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e_kubeadm/framework.go
+++ b/test/e2e_kubeadm/framework.go
@@ -20,5 +20,5 @@ import "github.com/onsi/ginkgo/v2"
 
 // Describe annotates the test with the Kubeadm label.
 func Describe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-cluster-lifecycle] [area-kubeadm] "+text, body)
+	return ginkgo.Describe("[sig-cluster-lifecycle] [area-kubeadm] "+text, ginkgo.Ordered, body)
 }

--- a/test/e2e_node/conformance/build/Dockerfile
+++ b/test/e2e_node/conformance/build/Dockerfile
@@ -38,7 +38,6 @@ ENV FOCUS="\[Conformance\]" \
 
 ENTRYPOINT ginkgo --focus="$FOCUS" \
 	--skip="$SKIP" \
-	--seed=0 \
 	--nodes=$PARALLELISM \
 	--flakeAttempts=$FLAKE_ATTEMPTS \
 	/usr/local/bin/e2e_node.test \

--- a/test/e2e_node/conformance/build/Dockerfile
+++ b/test/e2e_node/conformance/build/Dockerfile
@@ -38,6 +38,7 @@ ENV FOCUS="\[Conformance\]" \
 
 ENTRYPOINT ginkgo --focus="$FOCUS" \
 	--skip="$SKIP" \
+	--seed=0 \
 	--nodes=$PARALLELISM \
 	--flakeAttempts=$FLAKE_ATTEMPTS \
 	/usr/local/bin/e2e_node.test \

--- a/test/e2e_node/conformance/build/Dockerfile
+++ b/test/e2e_node/conformance/build/Dockerfile
@@ -38,7 +38,7 @@ ENV FOCUS="\[Conformance\]" \
 
 ENTRYPOINT ginkgo --focus="$FOCUS" \
 	--skip="$SKIP" \
-	--seed=0 \
+	--seed=17 \
 	--nodes=$PARALLELISM \
 	--flakeAttempts=$FLAKE_ATTEMPTS \
 	/usr/local/bin/e2e_node.test \

--- a/test/e2e_node/framework.go
+++ b/test/e2e_node/framework.go
@@ -20,5 +20,5 @@ import "github.com/onsi/ginkgo/v2"
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-node] "+text, body)
+	return ginkgo.Describe("[sig-node] "+text, ginkgo.Ordered, body)
 }

--- a/test/e2e_node/gcp/framework.go
+++ b/test/e2e_node/gcp/framework.go
@@ -20,5 +20,5 @@ import "github.com/onsi/ginkgo/v2"
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-cloud-provider-gcp] "+text, body)
+	return ginkgo.Describe("[sig-cloud-provider-gcp] "+text, ginkgo.Ordered, body)
 }


### PR DESCRIPTION
Extract conformance test

### Environment used

[kind](https://kind.sigs.k8s.io/)

### Build k8s conformance image

https://github.com/kubernetes/kubernetes/tree/master/test/conformance/image

```
REGISTRY_NAME=<az registry name>
az acr login --name $REGISTRY_NAME 
LOGIN_SERVER=$(az acr show --name $REGISTRY_NAME --query loginServer --output tsv  | sed 's/\r//g')

# In project root
make WHAT="test/e2e/e2e.test github.com/onsi/ginkgo/v2/ginkgo cmd/kubectl test/conformance/image/go-runner"
export REGISTRY=$LOGIN_SERVER

pushd test/conformance/image
TARGET_VERSION=dev
sudo -E make push VERSION=$TARGET_VERSION ARCH=amd64
popd

sonobuoy run --kube-conformance-image $LOGIN_SERVER/conformance:$TARGET_VERSION --e2e-focus='.*extract conformance test.*'
```

### result

```
2023/06/07 08:50:54 warn: calling test with e2e.test is deprecated and will be removed in 1.25, please rely on container manifest to invoke executable
2023/06/07 08:50:54 Running command:
Command env: []
Run from directory: 
Executable path: /usr/local/bin/ginkgo
Args (comma-delimited): /usr/local/bin/ginkgo,--focus=.*extract conformance test.*,--skip=\[Disruptive\]|NoExecuteTaintManager,--noColor=true,--timeout=24h,/usr/local/bin/e2e.test,--,--disable-log-dump,--repo-root=/kubernetes,--provider=local,--report-dir=/tmp/sonobuoy/results,--kubeconfig=,--progress-report-url=http://localhost:8099/progress
sep is " " args are "--progress-report-url=http://localhost:8099/progress"split [--progress-report-url=http://localhost:8099/progress]
2023/06/07 08:50:54 Now listening for interrupts
  I0607 08:50:54.637463      28 e2e.go:117] Starting e2e run "99750a7f-1cdf-4be2-90d9-90d684aa9328" on Ginkgo node 1
Running Suite: Kubernetes e2e suite - /usr/local/bin
====================================================
Random Seed: 1686127854 - will randomize all specs

Will run 1 of 7208 specs

[MYLOG] HTTP REQ:::&rest.Request{c:(*rest.RESTClient)(0xc0007df900), warningHandler:rest.WarningHandler(nil), rateLimiter:(*flowcontrol.tokenBucketRateLimiter)(0xc003032f30), backoff:(*rest.NoBackoff)(0x9bed590), timeout:0, maxRetries:10, verb:"GET", pathPrefix:"/api/v1", subpath:"", params:url.Values{"fieldSelector":[]string{"spec.unschedulable=false"}, "resourceVersion":[]string{"0"}}, headers:http.Header{"Accept":[]string{"application/json, */*"}}, namespace:"", namespaceSet:false, resource:"nodes", resourceName:"", subresource:"", err:error(nil), body:io.Reader(nil), bodyBytes:[]uint8(nil), retryFn:(rest.requestRetryFunc)(0x340d240)}

[MYLOG] HTTP REQ:::&rest.Request{c:(*rest.RESTClient)(0xc0007df900), warningHandler:rest.WarningHandler(nil), rateLimiter:(*flowcontrol.tokenBucketRateLimiter)(0xc003032f30), backoff:(*rest.NoBackoff)(0x9bed590), timeout:0, maxRetries:10, verb:"GET", pathPrefix:"/api/v1", subpath:"", params:url.Values{"fieldSelector":[]string{"spec.unschedulable=false"}}, headers:http.Header{"Accept":[]string{"application/json, */*"}}, namespace:"", namespaceSet:false, resource:"nodes", resourceName:"", subresource:"", err:error(nil), body:io.Reader(nil), bodyBytes:[]uint8(nil), retryFn:(rest.requestRetryFunc)(0x340d240)}

[MYLOG] HTTP REQ:kube-system::&rest.Request{c:(*rest.RESTClient)(0xc0007df900), warningHandler:rest.WarningHandler(nil), rateLimiter:(*flowcontrol.tokenBucketRateLimiter)(0xc003032f30), backoff:(*rest.NoBackoff)(0x9bed590), timeout:0, maxRetries:10, verb:"GET", pathPrefix:"/api/v1", subpath:"", params:url.Values(nil), headers:http.Header{"Accept":[]string{"application/json, */*"}}, namespace:"kube-system", namespaceSet:true, resource:"replicationcontrollers", resourceName:"", subresource:"", err:error(nil), body:io.Reader(nil), bodyBytes:[]uint8(nil), retryFn:(rest.requestRetryFunc)(0x340d240)}

[MYLOG] HTTP REQ:kube-system::&rest.Request{c:(*rest.RESTClient)(0xc0007ded20), warningHandler:rest.WarningHandler(nil), rateLimiter:(*flowcontrol.tokenBucketRateLimiter)(0xc003032810), backoff:(*rest.NoBackoff)(0x9bed590), timeout:0, maxRetries:10, verb:"GET", pathPrefix:"/apis/apps/v1", subpath:"", params:url.Values(nil), headers:http.Header{"Accept":[]string{"application/json, */*"}}, namespace:"kube-system", namespaceSet:true, resource:"replicasets", resourceName:"", subresource:"", err:error(nil), body:io.Reader(nil), bodyBytes:[]uint8(nil), retryFn:(rest.requestRetryFunc)(0x340d240)}

[MYLOG] HTTP REQ:kube-system::&rest.Request{c:(*rest.RESTClient)(0xc0007df900), warningHandler:rest.WarningHandler(nil), rateLimiter:(*flowcontrol.tokenBucketRateLimiter)(0xc003032f30), backoff:(*rest.NoBackoff)(0x9bed590), timeout:0, maxRetries:10, verb:"GET", pathPrefix:"/api/v1", subpath:"", params:url.Values(nil), headers:http.Header{"Accept":[]string{"application/json, */*"}}, namespace:"kube-system", namespaceSet:true, resource:"pods", resourceName:"", subresource:"", err:error(nil), body:io.Reader(nil), bodyBytes:[]uint8(nil), retryFn:(rest.requestRetryFunc)(0x340d240)}

[MYLOG] HTTP REQ:kube-system::&rest.Request{c:(*rest.RESTClient)(0xc0007ded20), warningHandler:rest.WarningHandler(nil), rateLimiter:(*flowcontrol.tokenBucketRateLimiter)(0xc003032810), backoff:(*rest.NoBackoff)(0x9bed590), timeout:0, maxRetries:10, verb:"GET", pathPrefix:"/apis/apps/v1", subpath:"", params:url.Values(nil), headers:http.Header{"Accept":[]string{"application/json, */*"}}, namespace:"kube-system", namespaceSet:true, resource:"daemonsets", resourceName:"", subresource:"", err:error(nil), body:io.Reader(nil), bodyBytes:[]uint8(nil), retryFn:(rest.requestRetryFunc)(0x340d240)}

[MYLOG] HTTP REQ:::&rest.Request{c:(*rest.RESTClient)(0xc0002e2be0), warningHandler:rest.WarningHandler(nil), rateLimiter:(*flowcontrol.tokenBucketRateLimiter)(0xc003033a10), backoff:(*rest.NoBackoff)(0x9bed590), timeout:0, maxRetries:10, verb:"GET", pathPrefix:"/version", subpath:"", params:url.Values(nil), headers:http.Header{"Accept":[]string{"application/json, */*"}}, namespace:"", namespaceSet:false, resource:"", resourceName:"", subresource:"", err:error(nil), body:io.Reader(nil), bodyBytes:[]uint8(nil), retryFn:(rest.requestRetryFunc)(0x340d240)}

[MYLOG] HTTP REQ:default::&rest.Request{c:(*rest.RESTClient)(0xc000300d20), warningHandler:rest.WarningHandler(nil), rateLimiter:(*flowcontrol.tokenBucketRateLimiter)(0xc0036e17a0), backoff:(*rest.NoBackoff)(0x9bed590), timeout:0, maxRetries:10, verb:"GET", pathPrefix:"/api/v1", subpath:"", params:url.Values(nil), headers:http.Header{"Accept":[]string{"application/json, */*"}}, namespace:"default", namespaceSet:true, resource:"services", resourceName:"kubernetes", subresource:"", err:error(nil), body:io.Reader(nil), bodyBytes:[]uint8(nil), retryFn:(rest.requestRetryFunc)(0x340d240)}
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
[MYLOG] HTTP REQ:::&rest.Request{c:(*rest.RESTClient)(0xc000933400), warningHandler:rest.WarningHandler(nil), rateLimiter:(*flowcontrol.tokenBucketRateLimiter)(0xc0043c9650), backoff:(*rest.NoBackoff)(0x9bed590), timeout:0, maxRetries:10, verb:"POST", pathPrefix:"/api/v1", subpath:"", params:url.Values(nil), headers:http.Header{"Accept":[]string{"application/vnd.kubernetes.protobuf, */*"}, "Content-Type":[]string{"application/vnd.kubernetes.protobuf"}}, namespace:"", namespaceSet:false, resource:"namespaces", resourceName:"", subresource:"", err:error(nil), body:io.Reader(nil), bodyBytes:[]uint8{0x6b, 0x38, 0x73, 0x0, 0xa, 0xf, 0xa, 0x2, 0x76, 0x31, 0x12, 0x9, 0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x12, 0xaa, 0x1, 0xa, 0xa1, 0x1, 0xa, 0x11, 0x6b, 0x75, 0x62, 0x65, 0x6c, 0x65, 0x74, 0x2d, 0x74, 0x65, 0x73, 0x74, 0x2d, 0x39, 0x35, 0x39, 0x35, 0x12, 0x0, 0x1a, 0x0, 0x22, 0x0, 0x2a, 0x0, 0x32, 0x0, 0x38, 0x0, 0x42, 0x0, 0x5a, 0x1d, 0xa, 0xd, 0x65, 0x32, 0x65, 0x2d, 0x66, 0x72, 0x61, 0x6d, 0x65, 0x77, 0x6f, 0x72, 0x6b, 0x12, 0xc, 0x6b, 0x75, 0x62, 0x65, 0x6c, 0x65, 0x74, 0x2d, 0x74, 0x65, 0x73, 0x74, 0x5a, 0x2f, 0xa, 0x7, 0x65, 0x32, 0x65, 0x2d, 0x72, 0x75, 0x6e, 0x12, 0x24, 0x39, 0x39, 0x37, 0x35, 0x30, 0x61, 0x37, 0x66, 0x2d, 0x31, 0x63, 0x64, 0x66, 0x2d, 0x34, 0x62, 0x65, 0x32, 0x2d, 0x39, 0x30, 0x64, 0x39, 0x2d, 0x39, 0x30, 0x64, 0x36, 0x38, 0x34, 0x61, 0x61, 0x39, 0x33, 0x32, 0x38, 0x5a, 0x2e, 0xa, 0x22, 0x70, 0x6f, 0x64, 0x2d, 0x73, 0x65, 0x63, 0x75, 0x72, 0x69, 0x74, 0x79, 0x2e, 0x6b, 0x75, 0x62, 0x65, 0x72, 0x6e, 0x65, 0x74, 0x65, 0x73, 0x2e, 0x69, 0x6f, 0x2f, 0x65, 0x6e, 0x66, 0x6f, 0x72, 0x63, 0x65, 0x12, 0x8, 0x62, 0x61, 0x73, 0x65, 0x6c, 0x69, 0x6e, 0x65, 0x12, 0x0, 0x1a, 0x2, 0xa, 0x0, 0x1a, 0x0, 0x22, 0x0}, retryFn:(rest.requestRetryFunc)(0x340d240)}

[MYLOG] HTTP REQ:kubelet-test-9595::&rest.Request{c:(*rest.RESTClient)(0xc000933400), warningHandler:rest.WarningHandler(nil), rateLimiter:(*flowcontrol.tokenBucketRateLimiter)(0xc0043c9650), backoff:(*rest.NoBackoff)(0x9bed590), timeout:0, maxRetries:10, verb:"GET", pathPrefix:"/api/v1", subpath:"", params:url.Values{"fieldSelector":[]string{"metadata.name=default"}, "limit":[]string{"500"}, "resourceVersion":[]string{"0"}}, headers:http.Header{"Accept":[]string{"application/vnd.kubernetes.protobuf, */*"}}, namespace:"kubelet-test-9595", namespaceSet:true, resource:"serviceaccounts", resourceName:"", subresource:"", err:error(nil), body:io.Reader(nil), bodyBytes:[]uint8(nil), retryFn:(rest.requestRetryFunc)(0x340d240)}

[MYLOG] HTTP REQ:kubelet-test-9595::&rest.Request{c:(*rest.RESTClient)(0xc000933400), warningHandler:rest.WarningHandler(nil), rateLimiter:(*flowcontrol.tokenBucketRateLimiter)(0xc0043c9650), backoff:(*rest.NoBackoff)(0x9bed590), timeout:0, maxRetries:10, verb:"GET", pathPrefix:"/api/v1", subpath:"", params:url.Values{"fieldSelector":[]string{"metadata.name=default"}, "limit":[]string{"500"}, "resourceVersion":[]string{"0"}}, headers:http.Header{"Accept":[]string{"application/vnd.kubernetes.protobuf, */*"}}, namespace:"kubelet-test-9595", namespaceSet:true, resource:"serviceaccounts", resourceName:"", subresource:"", err:error(nil), body:io.Reader(nil), bodyBytes:[]uint8(nil), retryFn:(rest.requestRetryFunc)(0x340d240)}

[MYLOG] HTTP REQ:kubelet-test-9595::&rest.Request{c:(*rest.RESTClient)(0xc000933400), warningHandler:rest.WarningHandler(nil), rateLimiter:(*flowcontrol.tokenBucketRateLimiter)(0xc0043c9650), backoff:(*rest.NoBackoff)(0x9bed590), timeout:0, maxRetries:10, verb:"GET", pathPrefix:"/api/v1", subpath:"", params:url.Values{"fieldSelector":[]string{"metadata.name=kube-root-ca.crt"}, "limit":[]string{"500"}, "resourceVersion":[]string{"0"}}, headers:http.Header{"Accept":[]string{"application/vnd.kubernetes.protobuf, */*"}}, namespace:"kubelet-test-9595", namespaceSet:true, resource:"configmaps", resourceName:"", subresource:"", err:error(nil), body:io.Reader(nil), bodyBytes:[]uint8(nil), retryFn:(rest.requestRetryFunc)(0x340d240)}
test logging by takurosato

[MYLOG] HTTP REQ:kubelet-test-9595::&rest.Request{c:(*rest.RESTClient)(0xc000933400), warningHandler:rest.WarningHandler(nil), rateLimiter:(*flowcontrol.tokenBucketRateLimiter)(0xc0043c9650), backoff:(*rest.NoBackoff)(0x9bed590), timeout:0, maxRetries:10, verb:"POST", pathPrefix:"/api/v1", subpath:"", params:url.Values(nil), headers:http.Header{"Accept":[]string{"application/vnd.kubernetes.protobuf, */*"}, "Content-Type":[]string{"application/vnd.kubernetes.protobuf"}}, namespace:"kubelet-test-9595", namespaceSet:true, resource:"pods", resourceName:"", subresource:"", err:error(nil), body:io.Reader(nil), bodyBytes:[]uint8{0x6b, 0x38, 0x73, 0x0, 0xa, 0x9, 0xa, 0x2, 0x76, 0x31, 0x12, 0x3, 0x50, 0x6f, 0x64, 0x12, 0xa7, 0x2, 0xa, 0x47, 0xa, 0x37, 0x62, 0x75, 0x73, 0x79, 0x62, 0x6f, 0x78, 0x2d, 0x73, 0x63, 0x68, 0x65, 0x64, 0x75, 0x6c, 0x69, 0x6e, 0x67, 0x2d, 0x61, 0x30, 0x63, 0x62, 0x62, 0x62, 0x30, 0x35, 0x2d, 0x37, 0x33, 0x35, 0x31, 0x2d, 0x34, 0x36, 0x37, 0x34, 0x2d, 0x39, 0x33, 0x36, 0x35, 0x2d, 0x38, 0x31, 0x38, 0x35, 0x64, 0x31, 0x30, 0x63, 0x33, 0x34, 0x61, 0x34, 0x12, 0x0, 0x1a, 0x0, 0x22, 0x0, 0x2a, 0x0, 0x32, 0x0, 0x38, 0x0, 0x42, 0x0, 0x12, 0xc9, 0x1, 0x12, 0xa5, 0x1, 0xa, 0x37, 0x62, 0x75, 0x73, 0x79, 0x62, 0x6f, 0x78, 0x2d, 0x73, 0x63, 0x68, 0x65, 0x64, 0x75, 0x6c, 0x69, 0x6e, 0x67, 0x2d, 0x61, 0x30, 0x63, 0x62, 0x62, 0x62, 0x30, 0x35, 0x2d, 0x37, 0x33, 0x35, 0x31, 0x2d, 0x34, 0x36, 0x37, 0x34, 0x2d, 0x39, 0x33, 0x36, 0x35, 0x2d, 0x38, 0x31, 0x38, 0x35, 0x64, 0x31, 0x30, 0x63, 0x33, 0x34, 0x61, 0x34, 0x12, 0x2e, 0x72, 0x65, 0x67, 0x69, 0x73, 0x74, 0x72, 0x79, 0x2e, 0x6b, 0x38, 0x73, 0x2e, 0x69, 0x6f, 0x2f, 0x65, 0x32, 0x65, 0x2d, 0x74, 0x65, 0x73, 0x74, 0x2d, 0x69, 0x6d, 0x61, 0x67, 0x65, 0x73, 0x2f, 0x62, 0x75, 0x73, 0x79, 0x62, 0x6f, 0x78, 0x3a, 0x31, 0x2e, 0x32, 0x39, 0x2d, 0x34, 0x1a, 0x2, 0x73, 0x68, 0x1a, 0x2, 0x2d, 0x63, 0x1a, 0x1e, 0x65, 0x63, 0x68, 0x6f, 0x20, 0x27, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64, 0x27, 0x20, 0x3b, 0x20, 0x73, 0x6c, 0x65, 0x65, 0x70, 0x20, 0x32, 0x34, 0x30, 0x2a, 0x0, 0x42, 0x0, 0x6a, 0x0, 0x72, 0x0, 0x80, 0x1, 0x0, 0x88, 0x1, 0x0, 0x90, 0x1, 0x0, 0xa2, 0x1, 0x0, 0x1a, 0x5, 0x4e, 0x65, 0x76, 0x65, 0x72, 0x32, 0x0, 0x42, 0x0, 0x4a, 0x0, 0x52, 0x0, 0x58, 0x0, 0x60, 0x0, 0x68, 0x0, 0x82, 0x1, 0x0, 0x8a, 0x1, 0x0, 0x9a, 0x1, 0x0, 0xc2, 0x1, 0x0, 0x1a, 0x10, 0xa, 0x0, 0x1a, 0x0, 0x22, 0x0, 0x2a, 0x0, 0x32, 0x0, 0x4a, 0x0, 0x5a, 0x0, 0x72, 0x0, 0x1a, 0x0, 0x22, 0x0}, retryFn:(rest.requestRetryFunc)(0x340d240)}

[MYLOG] HTTP REQ:kubelet-test-9595::&rest.Request{c:(*rest.RESTClient)(0xc000933400), warningHandler:rest.WarningHandler(nil), rateLimiter:(*flowcontrol.tokenBucketRateLimiter)(0xc0043c9650), backoff:(*rest.NoBackoff)(0x9bed590), timeout:0, maxRetries:10, verb:"GET", pathPrefix:"/api/v1", subpath:"", params:url.Values(nil), headers:http.Header{"Accept":[]string{"application/vnd.kubernetes.protobuf, */*"}}, namespace:"kubelet-test-9595", namespaceSet:true, resource:"pods", resourceName:"busybox-scheduling-a0cbbb05-7351-4674-9365-8185d10c34a4", subresource:"", err:error(nil), body:io.Reader(nil), bodyBytes:[]uint8(nil), retryFn:(rest.requestRetryFunc)(0x340d240)}

[MYLOG] HTTP REQ:kubelet-test-9595::&rest.Request{c:(*rest.RESTClient)(0xc000933400), warningHandler:rest.WarningHandler(nil), rateLimiter:(*flowcontrol.tokenBucketRateLimiter)(0xc0043c9650), backoff:(*rest.NoBackoff)(0x9bed590), timeout:0, maxRetries:10, verb:"GET", pathPrefix:"/api/v1", subpath:"", params:url.Values(nil), headers:http.Header{"Accept":[]string{"application/vnd.kubernetes.protobuf, */*"}}, namespace:"kubelet-test-9595", namespaceSet:true, resource:"pods", resourceName:"busybox-scheduling-a0cbbb05-7351-4674-9365-8185d10c34a4", subresource:"", err:error(nil), body:io.Reader(nil), bodyBytes:[]uint8(nil), retryFn:(rest.requestRetryFunc)(0x340d240)}

[MYLOG] HTTP REQ:kubelet-test-9595::&rest.Request{c:(*rest.RESTClient)(0xc000933400), warningHandler:rest.WarningHandler(nil), rateLimiter:(*flowcontrol.tokenBucketRateLimiter)(0xc0043c9650), backoff:(*rest.NoBackoff)(0x9bed590), timeout:0, maxRetries:10, verb:"GET", pathPrefix:"/api/v1", subpath:"", params:url.Values(nil), headers:http.Header{"Accept":[]string{"application/vnd.kubernetes.protobuf, */*"}}, namespace:"kubelet-test-9595", namespaceSet:true, resource:"pods", resourceName:"busybox-scheduling-a0cbbb05-7351-4674-9365-8185d10c34a4", subresource:"", err:error(nil), body:io.Reader(nil), bodyBytes:[]uint8(nil), retryFn:(rest.requestRetryFunc)(0x340d240)}

[MYLOG] HTTP REQ:::&rest.Request{c:(*rest.RESTClient)(0xc000933400), warningHandler:rest.WarningHandler(nil), rateLimiter:(*flowcontrol.tokenBucketRateLimiter)(0xc0043c9650), backoff:(*rest.NoBackoff)(0x9bed590), timeout:0, maxRetries:10, verb:"GET", pathPrefix:"/api/v1", subpath:"", params:url.Values(nil), headers:http.Header{"Accept":[]string{"application/vnd.kubernetes.protobuf, */*"}}, namespace:"", namespaceSet:false, resource:"nodes", resourceName:"", subresource:"", err:error(nil), body:io.Reader(nil), bodyBytes:[]uint8(nil), retryFn:(rest.requestRetryFunc)(0x340d240)}

[MYLOG] HTTP REQ:::&rest.Request{c:(*rest.RESTClient)(0xc000933400), warningHandler:rest.WarningHandler(nil), rateLimiter:(*flowcontrol.tokenBucketRateLimiter)(0xc0043c9650), backoff:(*rest.NoBackoff)(0x9bed590), timeout:0, maxRetries:10, verb:"DELETE", pathPrefix:"/api/v1", subpath:"", params:url.Values(nil), headers:http.Header{"Accept":[]string{"application/vnd.kubernetes.protobuf, */*"}, "Content-Type":[]string{"application/vnd.kubernetes.protobuf"}}, namespace:"", namespaceSet:false, resource:"namespaces", resourceName:"kubelet-test-9595", subresource:"", err:error(nil), body:io.Reader(nil), bodyBytes:[]uint8{0x6b, 0x38, 0x73, 0x0, 0xa, 0x13, 0xa, 0x2, 0x76, 0x31, 0x12, 0xd, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x0, 0x1a, 0x0, 0x22, 0x0}, retryFn:(rest.requestRetryFunc)(0x340d240)}
•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 7208 Specs in 2.485 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 7207 Skipped
PASS

Ginkgo ran 1 suite in 2.849863497s
Test Suite Passed
[38;5;228mYou're using deprecated Ginkgo functionality:[0m
[38;5;228m=============================================[0m
  [38;5;11m--noColor is deprecated, use --no-color instead[0m
  [1mLearn more at:[0m [38;5;14m[4mhttps://onsi.github.io/ginkgo/MIGRATING_TO_V2#changed-command-line-flags[0m

[38;5;243mTo silence deprecations that can be silenced set the following environment variable:[0m
  [38;5;243mACK_GINKGO_DEPRECATIONS=2.9.1[0m

2023/06/07 08:50:57 Saving results at /tmp/sonobuoy/results

```

### memo: how to fetch result

https://github.com/vmware-tanzu/sonobuoy

```bash
# wait until finish
sonobuoy status

results=$(sonobuoy retrieve)
sonobuoy results $results # you should find e2e.text in the output

sonobuoy delete --wait

mkdir "${results}_dir"
tar -xvf $results -C "${results}_dir"

code $(find ${results}_dir -name 'e2e.txt')

```
